### PR TITLE
Add CI for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,6 +165,8 @@ The website includes a dedicated `/contribute` page with instructions:
 
 Runs on pull requests and pushes to `main`.
 
+Dependabot PRs are also validated by the same CI workflow, and dependency updates are managed via `.github/dependabot.yml`.
+
 ## 9. Deployment architecture
 
 ### Trigger policy


### PR DESCRIPTION
## Why
This change adds automated dependency maintenance so dependency drift is handled continuously instead of manually. It also makes sure those bot-generated updates are validated by the same CI quality gates before merge.

## What changed
- Added `.github/dependabot.yml` to enable Dependabot updates for `npm` and `github-actions`.
- Added explicit workflow permissions in `.github/workflows/ci.yml` with `contents: read` for least-privilege CI runs.
- Updated `ARCHITECTURE.md` to document that Dependabot PRs are checked by the same CI pipeline.

Closes #3.

## Notes for reviewers
- CI gate order and deployment behavior were intentionally left unchanged.
- Scope is limited to dependency update automation and related CI/documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated daily checks for dependency updates across npm packages and GitHub Actions workflows
  * Enhanced CI workflow security with explicit read-only permissions for repository contents

* **Documentation**
  * Updated architecture documentation to clarify the automated dependency update workflow and CI integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->