### PR TITLE
Add issue templates with auto labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a reproducible problem in cp-editorial-frontend
+title: '[Bug] '
+labels: bug
+---
+
+## Bug description
+
+Clearly and concisely describe the bug.
+
+## Steps to reproduce
+
+1. Go to "..."
+2. Click on "..."
+3. Scroll down to "..."
+4. See error
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe what actually happened.
+
+## Environment
+
+- OS:
+- Browser:
+- App version/commit (if known):
+
+## Logs or screenshots
+
+Paste relevant logs, error output, or screenshots.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for cp-editorial-frontend
+title: '[Feature] '
+labels: enhancement
+---
+
+## Summary
+
+Briefly describe the feature you want.
+
+## Problem to solve
+
+What problem does this feature solve?  
+Who is affected?
+
+## Proposed solution
+
+Describe your preferred solution in detail.
+
+## Alternatives considered
+
+List any alternative approaches you considered.
+
+## Additional context
+
+Add examples, screenshots, links, or related issues if applicable.


### PR DESCRIPTION
## Why
Issue #15 requests standardized issue intake so bug reports and feature requests are submitted with consistent, reviewable details.

## What changed
- Added `.github/ISSUE_TEMPLATE/BUG_REPORT.md` with front matter and sections for summary, reproducible steps, expected vs actual behavior, environment, and extra context.
- Added `.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md` with front matter and sections for problem statement, proposed solution, alternatives, and extra context.

Closes #15.

## Notes
- Filenames match the issue request exactly: `BUG_REPORT.md` and `FEATURE_REQUEST.md`.
- Scope is limited to issue templates only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced issue templates for bug reports and feature requests to standardize community contributions, with structured guidance for reproduction steps, environment details, expected behaviors, and implementation suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->