### PR TITLE
Add copyright information page and navigation links

### DIFF
--- a/src/app/routes/AppRouter.tsx
+++ b/src/app/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import { CategoryPage } from '../../pages/CategoryPage'
 import { CategoryContestPage } from '../../pages/CategoryContestPage'
 import { CategoriesPage } from '../../pages/CategoriesPage'
 import { ContributePage } from '../../pages/ContributePage'
+import { CopyrightPage } from '../../pages/CopyrightPage'
 import { EditorialDetailPage } from '../../pages/EditorialDetailPage'
 import { HomePage } from '../../pages/HomePage'
 import { SearchPage } from '../../pages/SearchPage'
@@ -19,6 +20,7 @@ export function AppRouter() {
         <Route element={<CategoryContestPage />} path="categories/:category/contests/:contest" />
         <Route element={<EditorialDetailPage />} path="editorials/:editorialId" />
         <Route element={<ContributePage />} path="contribute" />
+        <Route element={<CopyrightPage />} path="copyright" />
       </Route>
       <Route element={<Navigate replace to="/" />} path="*" />
     </Routes>

--- a/src/pages/CopyrightPage.tsx
+++ b/src/pages/CopyrightPage.tsx
@@ -1,0 +1,62 @@
+import { Trans, useTranslation } from 'react-i18next'
+
+export function CopyrightPage() {
+  const { t } = useTranslation()
+
+  return (
+    <section className="page">
+      <h1>{t('copyrightPage.heading')}</h1>
+      <p className="page__description">{t('copyrightPage.description')}</p>
+
+      <article className="card contribute-guide">
+        <h2 className="card__title">{t('copyrightPage.ownership.heading')}</h2>
+        <p className="card__meta">
+          <Trans
+            components={{
+              dataRepo: (
+                <a
+                  href="https://github.com/utilForever/cp-editorial-data"
+                  rel="noreferrer"
+                  target="_blank"
+                />
+              ),
+            }}
+            i18nKey="copyrightPage.ownership.body"
+          />
+        </p>
+      </article>
+
+      <article className="card contribute-guide">
+        <h2 className="card__title">{t('copyrightPage.attribution.heading')}</h2>
+        <ul className="guide-list">
+          <li>{t('copyrightPage.attribution.item1')}</li>
+          <li>{t('copyrightPage.attribution.item2')}</li>
+          <li>{t('copyrightPage.attribution.item3')}</li>
+        </ul>
+      </article>
+
+      <article className="card contribute-guide">
+        <h2 className="card__title">{t('copyrightPage.usage.heading')}</h2>
+        <p className="card__meta">{t('copyrightPage.usage.body')}</p>
+      </article>
+
+      <article className="card contribute-guide">
+        <h2 className="card__title">{t('copyrightPage.removal.heading')}</h2>
+        <p className="card__meta">
+          <Trans
+            components={{
+              issues: (
+                <a
+                  href="https://github.com/utilForever/cp-editorial-data/issues"
+                  rel="noreferrer"
+                  target="_blank"
+                />
+              ),
+            }}
+            i18nKey="copyrightPage.removal.body"
+          />
+        </p>
+      </article>
+    </section>
+  )
+}

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -10,6 +10,7 @@ export const resources = {
         search: 'Search',
         categories: 'Categories',
         contribute: 'Upload Guide',
+        copyright: 'Copyright',
       },
       footer: {
         description: 'A curated archive for competitive-programming contest editorials.',
@@ -19,6 +20,7 @@ export const resources = {
           search: 'Find Competitions',
           categories: 'Browse Categories',
           contribute: 'Upload Guide',
+          copyright: 'Copyright Policy',
         },
         links: {
           heading: 'Repositories',
@@ -134,6 +136,30 @@ export const resources = {
         footer:
           'If deployment did not refresh data, check the cross-repo dispatch workflow and static index artifact version.',
       },
+      copyrightPage: {
+        heading: 'Editorial Copyright & Usage',
+        description:
+          'This page explains ownership, attribution, and usage expectations for editorial content listed in CP Editorial.',
+        ownership: {
+          heading: 'Ownership',
+          body: 'Editorial files listed here remain the property of their original authors or rights holders. CP Editorial only indexes and links files managed in <dataRepo>cp-editorial-data</dataRepo>.',
+        },
+        attribution: {
+          heading: 'Attribution expectations',
+          item1:
+            'When sharing or quoting editorial content, preserve original author, contest, and source information.',
+          item2: 'Include a clear reference to the original source repository or publication.',
+          item3: 'Do not remove existing credit, watermark, or license notices from files.',
+        },
+        usage: {
+          heading: 'Permitted use',
+          body: 'Use this archive for learning and reference. Redistribution or republication should follow each source author or organization policy.',
+        },
+        removal: {
+          heading: 'Contact and removal requests',
+          body: 'If you are a rights holder and need a correction, attribution update, or removal, open an issue in <issues>Issues in utilForever/cp-editorial-data</issues> with the file path and request details.',
+        },
+      },
       language: {
         label: 'Language',
       },
@@ -150,6 +176,7 @@ export const resources = {
         search: '검색',
         categories: '카테고리',
         contribute: '업로드 가이드',
+        copyright: '저작권',
       },
       footer: {
         description: '경쟁 프로그래밍 대회 에디토리얼을 모아 둔 아카이브입니다.',
@@ -159,6 +186,7 @@ export const resources = {
           search: '대회 찾기',
           categories: '카테고리 보기',
           contribute: '업로드 가이드',
+          copyright: '저작권 안내',
         },
         links: {
           heading: '저장소',
@@ -271,6 +299,29 @@ export const resources = {
         footer:
           '데이터가 갱신되지 않으면 cross-repo dispatch 워크플로와 인덱스 아티팩트 버전을 확인하세요.',
       },
+      copyrightPage: {
+        heading: '에디토리얼 저작권 및 이용 안내',
+        description:
+          '이 페이지는 CP Editorial에 등록된 에디토리얼 콘텐츠의 소유권, 출처 표기, 이용 기준을 설명합니다.',
+        ownership: {
+          heading: '소유권',
+          body: '이 사이트에 표시되는 에디토리얼 파일의 권리는 원저자 또는 권리자에게 있습니다. CP Editorial은 <dataRepo>cp-editorial-data</dataRepo>에서 관리되는 파일을 인덱싱하고 링크만 제공합니다.',
+        },
+        attribution: {
+          heading: '출처 표기 원칙',
+          item1: '에디토리얼 내용을 공유하거나 인용할 때 원저자, 대회명, 출처 정보를 유지하세요.',
+          item2: '원본 저장소 또는 게시 위치를 명확히 함께 표기하세요.',
+          item3: '파일에 포함된 저작권 고지, 워터마크, 라이선스 문구를 제거하지 마세요.',
+        },
+        usage: {
+          heading: '이용 범위',
+          body: '이 아카이브는 학습과 참고 용도로 사용하세요. 재배포 또는 재게시는 각 원저자/기관의 정책을 따라야 합니다.',
+        },
+        removal: {
+          heading: '문의 및 삭제 요청',
+          body: '권리자이며 정정, 출처 수정, 삭제가 필요한 경우 파일 경로와 요청 사유를 포함해 <issues>utilForever/cp-editorial-data의 Issues</issues>에 이슈를 등록해 주세요.',
+        },
+      },
       language: {
         label: '언어',
       },
@@ -287,6 +338,7 @@ export const resources = {
         search: '検索',
         categories: 'カテゴリ',
         contribute: 'アップロードガイド',
+        copyright: '著作権',
       },
       footer: {
         description: '競技プログラミング大会のエディトリアルを集約したアーカイブです。',
@@ -296,6 +348,7 @@ export const resources = {
           search: '大会を探す',
           categories: 'カテゴリを見る',
           contribute: 'アップロードガイド',
+          copyright: '著作権案内',
         },
         links: {
           heading: 'リポジトリ',
@@ -409,6 +462,30 @@ export const resources = {
         },
         footer:
           '更新が反映されない場合は、cross-repo dispatch ワークフローとインデックス成果物のバージョンを確認してください。',
+      },
+      copyrightPage: {
+        heading: 'エディトリアルの著作権と利用方針',
+        description:
+          'このページでは、CP Editorial に掲載されるエディトリアルの権利帰属、出典表記、利用上の注意を説明します。',
+        ownership: {
+          heading: '権利帰属',
+          body: '掲載されているエディトリアルファイルの権利は、元の著者または権利者に帰属します。CP Editorial は <dataRepo>cp-editorial-data</dataRepo> で管理されるファイルを索引化し、リンクのみを提供します。',
+        },
+        attribution: {
+          heading: '出典表記の方針',
+          item1:
+            'エディトリアル内容を共有・引用する際は、著者名・大会名・出典情報を維持してください。',
+          item2: '元のリポジトリまたは公開元への明確な参照を付けてください。',
+          item3: '既存のクレジット、ウォーターマーク、ライセンス表記を削除しないでください。',
+        },
+        usage: {
+          heading: '利用範囲',
+          body: '本アーカイブは学習・参照目的で利用してください。再配布や再掲載は、各著者・団体の方針に従ってください。',
+        },
+        removal: {
+          heading: '問い合わせ・削除依頼',
+          body: '権利者として修正、出典更新、削除が必要な場合は、対象ファイルのパスと依頼内容を添えて <issues>utilForever/cp-editorial-data の Issues</issues> に issue を作成してください。',
+        },
       },
       language: {
         label: '言語',

--- a/src/shared/ui/Layout.tsx
+++ b/src/shared/ui/Layout.tsx
@@ -28,6 +28,9 @@ export function Layout() {
             <NavLink className={navLinkClassName} to="/contribute">
               {t('nav.contribute')}
             </NavLink>
+            <NavLink className={navLinkClassName} to="/copyright">
+              {t('nav.copyright')}
+            </NavLink>
             <LanguageSelector />
           </nav>
         </div>
@@ -64,6 +67,9 @@ export function Layout() {
               </Link>
               <Link className="layout__footer-link" to="/contribute">
                 {t('footer.explore.contribute')}
+              </Link>
+              <Link className="layout__footer-link" to="/copyright">
+                {t('footer.explore.copyright')}
               </Link>
             </section>
 


### PR DESCRIPTION
## What

- Add a new `/copyright` page with editorial ownership, attribution, usage, and removal-request guidance.
- Add global entry points to the page from the header navigation and footer Explore section.
- Add i18n updates for `en`, `ko`, and `ja`, including localized issue-link label wording.

## Why

Issue #32 asks for a dedicated copyright policy page that users can reach both by direct URL and from global navigation. This improves clarity around editorial ownership and gives rights holders a clear removal/contact path.

Closes #32

## Checklist

### Required

- [ ] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [ ] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Copyright page with information about editorial ownership, attribution requirements, permitted usage, and removal request procedures.
  * Copyright page is now accessible from the main navigation and footer.
  * Copyright page content is available in English, Korean, and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->