### PR TITLE
Support dark mode and persist language preference

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,7 @@ Core goals:
 3. Consume editorial metadata from `cp-editorial-data`.
 4. Support Unicode editorial filenames safely.
 5. Automatically deploy to `https://editorial.coduck.io` when editorial data is updated.
+6. Support user-selectable light/dark theme with persisted preference.
 
 ## 2. System context
 
@@ -145,7 +146,13 @@ Normalization rejects invalid index data (missing required fields or empty local
   4. `ja`
   5. first available value
 
-## 7. Upload guidance flow
+## 7. UI preferences
+
+- Theme supports `light` and `dark`.
+- Active theme is selected in the header and persisted in browser local storage.
+- Theme is applied at the document root via `data-theme`, so all routed pages share one consistent palette.
+
+## 8. Upload guidance flow
 
 The website includes a dedicated `/contribute` page with instructions:
 
@@ -154,7 +161,7 @@ The website includes a dedicated `/contribute` page with instructions:
 3. Keep only editorial source files in target folders (non-editorial files are excluded by config).
 4. Merge PR to `main` to trigger index regeneration + frontend deployment.
 
-## 8. CI quality architecture
+## 9. CI quality architecture
 
 `ci.yml` enforces:
 
@@ -173,7 +180,7 @@ Runs on pull requests and pushes to `main`.
 
 Dependabot PRs are also validated by the CI workflow, and dependency updates are managed via `.github/dependabot.yml`.
 
-## 9. Deployment architecture
+## 10. Deployment architecture
 
 ### Trigger policy
 
@@ -197,7 +204,7 @@ On `cp-editorial-data` main updates:
 3. Frontend rebuilds with latest index.
 4. Updated site is published to `https://editorial.coduck.io`.
 
-## 10. Future extensions
+## 11. Future extensions
 
 - Incremental index partitions for very large editorial sets.
 - Full-text search index generation in data pipeline.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ npm run analyze
 npm run build
 ```
 
+## UI preferences
+
+- Theme: switch between light and dark mode from the header; the selected mode is saved in local storage.
+- Language: switch UI language at runtime (`en`, `ko`, `ja`).
+
 ## The way the system works
 
 1. Editorial files are managed in `cp-editorial-data`.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm run build
 ## UI preferences
 
 - Theme: switch between light and dark mode from the header; the selected mode is saved in local storage.
-- Language: switch UI language at runtime (`en`, `ko`, `ja`).
+- Language: switch UI language at runtime (`en`, `ko`, `ja`); the selected language is also saved in local storage.
 
 ## The way the system works
 

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -20,6 +20,12 @@
   --color-download-bg: #fbe3af;
   --color-download-border: #c79a56;
   --color-download-text: #271909;
+  --color-input-bg: #ffffff;
+  --color-input-text: #271909;
+  --color-error-text: #b91c1c;
+  --color-error-bg: #fef2f2;
+  --color-error-border: #fecaca;
+  --color-focus-ring: #866531;
 
   font-family:
     Inter,
@@ -38,6 +44,36 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+[data-theme='dark'] {
+  --color-text-primary: #f5e8cf;
+  --color-bg-app: #18110a;
+  --color-surface: #24180e;
+  --color-border: #5d4626;
+  --color-border-strong: #8b6738;
+  --color-muted: #d4b98e;
+  --color-muted-soft: #b49161;
+  --color-primary: #f0c47f;
+  --color-primary-strong: #fde5bd;
+  --color-primary-soft: #3a2713;
+  --color-accent: #f4c479;
+  --color-footer-bg: #120c06;
+  --color-footer-border: #3b2a16;
+  --color-footer-text: #f8e7c8;
+  --color-footer-muted: #d2ad77;
+  --color-view-bg: #1e2f47;
+  --color-view-border: #4672ae;
+  --color-view-text: #cbe1ff;
+  --color-download-bg: #3a2b12;
+  --color-download-border: #a17a3e;
+  --color-download-text: #ffe0a8;
+  --color-input-bg: #1d130a;
+  --color-input-text: #f5e8cf;
+  --color-error-text: #fecaca;
+  --color-error-bg: #3a1111;
+  --color-error-border: #7f1d1d;
+  --color-focus-ring: #f4c479;
+}
+
 *,
 *::before,
 *::after {
@@ -48,6 +84,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-app);
 }
 
 a {
@@ -250,6 +288,12 @@ a {
   border-radius: 0.5rem;
   padding: 0.6rem 0.75rem;
   font: inherit;
+  color: var(--color-input-text);
+  background-color: var(--color-input-bg);
+}
+
+.input::placeholder {
+  color: var(--color-muted-soft);
 }
 
 .card-list {
@@ -397,9 +441,9 @@ a {
 }
 
 .error {
-  color: #b91c1c;
-  background-color: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--color-error-text);
+  background-color: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
   padding: 0.8rem;
   border-radius: 0.6rem;
 }
@@ -410,6 +454,43 @@ a {
   padding: 0.35rem 0.5rem;
   background-color: var(--color-surface);
   font: inherit;
+  color: var(--color-text-primary);
+}
+
+.theme-toggle {
+  border: 1px solid var(--color-border-strong);
+  border-radius: 999px;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  padding: 0;
+}
+
+.theme-toggle:hover {
+  background-color: var(--color-primary-soft);
+}
+
+.theme-toggle__icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.layout__link:focus-visible,
+.layout__footer-link:focus-visible,
+.layout__footer-external:focus-visible,
+.card__title:focus-visible,
+.competition-editorials__title:focus-visible,
+.action-link:focus-visible,
+.input:focus-visible,
+.language-selector:focus-visible,
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }
 
 @media (max-width: 760px) {

--- a/src/shared/hooks/useThemePreference.ts
+++ b/src/shared/hooks/useThemePreference.ts
@@ -13,11 +13,42 @@ function toTheme(value: string | null): Theme | null {
 }
 
 function getSystemTheme(): Theme {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  return globalThis.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function isStorageUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'SecurityError' || error.name === 'QuotaExceededError')
+  )
+}
+
+function getStoredTheme(): Theme | null {
+  try {
+    return toTheme(globalThis.localStorage.getItem(THEME_STORAGE_KEY))
+  } catch (error) {
+    if (isStorageUnavailableError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+function persistTheme(theme: Theme) {
+  try {
+    globalThis.localStorage.setItem(THEME_STORAGE_KEY, theme)
+  } catch (error) {
+    if (isStorageUnavailableError(error)) {
+      return
+    }
+
+    throw error
+  }
 }
 
 function getInitialTheme(): Theme {
-  const savedTheme = toTheme(window.localStorage.getItem(THEME_STORAGE_KEY))
+  const savedTheme = getStoredTheme()
   if (savedTheme) {
     return savedTheme
   }
@@ -26,8 +57,8 @@ function getInitialTheme(): Theme {
 }
 
 function applyThemeToDocument(theme: Theme) {
-  document.documentElement.dataset.theme = theme
-  document.documentElement.style.colorScheme = theme
+  globalThis.document.documentElement.dataset.theme = theme
+  globalThis.document.documentElement.style.colorScheme = theme
 }
 
 export function useThemePreference() {
@@ -35,7 +66,7 @@ export function useThemePreference() {
 
   useEffect(() => {
     applyThemeToDocument(theme)
-    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+    persistTheme(theme)
   }, [theme])
 
   return { theme, setTheme }

--- a/src/shared/hooks/useThemePreference.ts
+++ b/src/shared/hooks/useThemePreference.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+const THEME_STORAGE_KEY = 'cp-editorial-theme'
+
+function toTheme(value: string | null): Theme | null {
+  if (value === 'light' || value === 'dark') {
+    return value
+  }
+
+  return null
+}
+
+function getSystemTheme(): Theme {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function getInitialTheme(): Theme {
+  const savedTheme = toTheme(window.localStorage.getItem(THEME_STORAGE_KEY))
+  if (savedTheme) {
+    return savedTheme
+  }
+
+  return getSystemTheme()
+}
+
+function applyThemeToDocument(theme: Theme) {
+  document.documentElement.dataset.theme = theme
+  document.documentElement.style.colorScheme = theme
+}
+
+export function useThemePreference() {
+  const [theme, setTheme] = useState<Theme>(() => getInitialTheme())
+
+  useEffect(() => {
+    applyThemeToDocument(theme)
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+  }, [theme])
+
+  return { theme, setTheme }
+}

--- a/src/shared/i18n/getLocalizedText.ts
+++ b/src/shared/i18n/getLocalizedText.ts
@@ -2,11 +2,20 @@ import type { LocalizedContent } from '../../entities/editorial/model/types'
 
 const FALLBACK_LOCALES = ['en', 'ko', 'ja']
 
+function normalizeLocale(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  return value.toLowerCase().split(/[-_]/)[0]
+}
+
 export function getLocalizedText(
   content: LocalizedContent,
   preferredLocale: string | undefined,
 ): string {
-  const preferredText = preferredLocale ? content[preferredLocale]?.trim() : undefined
+  const normalizedLocale = normalizeLocale(preferredLocale)
+  const preferredText = normalizedLocale ? content[normalizedLocale]?.trim() : undefined
   if (preferredText) {
     return preferredText
   }

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -27,7 +27,7 @@ function toSupportedLanguage(value: string | null | undefined): SupportedLanguag
 }
 
 function resolveInitialLanguage() {
-  return toSupportedLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY)) ?? DEFAULT_LANGUAGE
+  return toSupportedLanguage(globalThis.localStorage.getItem(LANGUAGE_STORAGE_KEY)) ?? DEFAULT_LANGUAGE
 }
 
 function syncDocumentLanguage(language: string) {

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -26,8 +26,40 @@ function toSupportedLanguage(value: string | null | undefined): SupportedLanguag
   return normalized as SupportedLanguage
 }
 
+function isStorageUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'SecurityError' || error.name === 'QuotaExceededError')
+  )
+}
+
+function getLanguageStorage(): Storage | null {
+  try {
+    return globalThis.localStorage
+  } catch (error) {
+    if (isStorageUnavailableError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
 function resolveInitialLanguage() {
-  return toSupportedLanguage(globalThis.localStorage.getItem(LANGUAGE_STORAGE_KEY)) ?? DEFAULT_LANGUAGE
+  const storage = getLanguageStorage()
+  if (!storage) {
+    return DEFAULT_LANGUAGE
+  }
+
+  try {
+    return toSupportedLanguage(storage.getItem(LANGUAGE_STORAGE_KEY)) ?? DEFAULT_LANGUAGE
+  } catch (error) {
+    if (isStorageUnavailableError(error)) {
+      return DEFAULT_LANGUAGE
+    }
+
+    throw error
+  }
 }
 
 function syncDocumentLanguage(language: string) {
@@ -35,12 +67,25 @@ function syncDocumentLanguage(language: string) {
 }
 
 function syncLanguagePreference(language: string) {
+  const storage = getLanguageStorage()
+  if (!storage) {
+    return
+  }
+
   const supportedLanguage = toSupportedLanguage(language)
   if (!supportedLanguage) {
     return
   }
 
-  globalThis.localStorage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage)
+  try {
+    storage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage)
+  } catch (error) {
+    if (isStorageUnavailableError(error)) {
+      return
+    }
+
+    throw error
+  }
 }
 
 function handleLanguageChange(language: string) {

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -40,7 +40,7 @@ function syncLanguagePreference(language: string) {
     return
   }
 
-  window.localStorage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage)
+  globalThis.localStorage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage)
 }
 
 function handleLanguageChange(language: string) {

--- a/src/shared/i18n/i18n.ts
+++ b/src/shared/i18n/i18n.ts
@@ -2,22 +2,67 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import { resources } from './resources'
 
+const DEFAULT_LANGUAGE = 'en'
+const LANGUAGE_STORAGE_KEY = 'cp-editorial-language'
+const SUPPORTED_LANGUAGE_CODES = ['en', 'ko', 'ja'] as const
+const SUPPORTED_LANGUAGE_SET = new Set<string>(SUPPORTED_LANGUAGE_CODES)
+
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGE_CODES)[number]
+
+function normalizeLanguage(value: string | null | undefined): string | null {
+  if (!value) {
+    return null
+  }
+
+  return value.toLowerCase().split(/[-_]/)[0] ?? null
+}
+
+function toSupportedLanguage(value: string | null | undefined): SupportedLanguage | null {
+  const normalized = normalizeLanguage(value)
+  if (!normalized || !SUPPORTED_LANGUAGE_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as SupportedLanguage
+}
+
+function resolveInitialLanguage() {
+  return toSupportedLanguage(window.localStorage.getItem(LANGUAGE_STORAGE_KEY)) ?? DEFAULT_LANGUAGE
+}
+
 function syncDocumentLanguage(language: string) {
   document.documentElement.lang = language
+}
+
+function syncLanguagePreference(language: string) {
+  const supportedLanguage = toSupportedLanguage(language)
+  if (!supportedLanguage) {
+    return
+  }
+
+  window.localStorage.setItem(LANGUAGE_STORAGE_KEY, supportedLanguage)
+}
+
+function handleLanguageChange(language: string) {
+  syncDocumentLanguage(language)
+  syncLanguagePreference(language)
 }
 
 void i18n
   .use(initReactI18next)
   .init({
     resources,
-    lng: 'en',
-    fallbackLng: 'en',
+    lng: resolveInitialLanguage(),
+    fallbackLng: DEFAULT_LANGUAGE,
+    supportedLngs: SUPPORTED_LANGUAGE_CODES,
+    nonExplicitSupportedLngs: true,
+    load: 'languageOnly',
     interpolation: {
       escapeValue: false,
     },
   })
   .then(() => {
-    syncDocumentLanguage(i18n.resolvedLanguage ?? i18n.language)
+    handleLanguageChange(i18n.resolvedLanguage ?? i18n.language)
   })
 
-i18n.on('languageChanged', syncDocumentLanguage)
+i18n.on('languageChanged', handleLanguageChange)

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -163,6 +163,13 @@ export const resources = {
       language: {
         label: 'Language',
       },
+      theme: {
+        label: 'Theme',
+        light: 'Light',
+        dark: 'Dark',
+        switchToLight: 'Switch to light theme',
+        switchToDark: 'Switch to dark theme',
+      },
     },
   },
   ko: {
@@ -324,6 +331,13 @@ export const resources = {
       },
       language: {
         label: '언어',
+      },
+      theme: {
+        label: '테마',
+        light: '라이트',
+        dark: '다크',
+        switchToLight: '라이트 테마로 전환',
+        switchToDark: '다크 테마로 전환',
       },
     },
   },
@@ -489,6 +503,13 @@ export const resources = {
       },
       language: {
         label: '言語',
+      },
+      theme: {
+        label: 'テーマ',
+        light: 'ライト',
+        dark: 'ダーク',
+        switchToLight: 'ライトテーマに切り替え',
+        switchToDark: 'ダークテーマに切り替え',
       },
     },
   },

--- a/src/shared/ui/LanguageSelector.tsx
+++ b/src/shared/ui/LanguageSelector.tsx
@@ -5,10 +5,23 @@ const SUPPORTED_LANGUAGES = [
   { code: 'ko', label: '한국어' },
   { code: 'ja', label: '日本語' },
 ]
+const SUPPORTED_LANGUAGE_CODES = new Set(SUPPORTED_LANGUAGES.map((language) => language.code))
+const DEFAULT_LANGUAGE = 'en'
+
+function normalizeLanguage(language: string | undefined) {
+  if (!language) {
+    return DEFAULT_LANGUAGE
+  }
+
+  return language.toLowerCase().split(/[-_]/)[0] ?? DEFAULT_LANGUAGE
+}
 
 export function LanguageSelector() {
   const { t, i18n } = useTranslation()
-  const currentLanguage = i18n.resolvedLanguage ?? 'en'
+  const normalizedLanguage = normalizeLanguage(i18n.resolvedLanguage ?? i18n.language)
+  const currentLanguage = SUPPORTED_LANGUAGE_CODES.has(normalizedLanguage)
+    ? normalizedLanguage
+    : DEFAULT_LANGUAGE
 
   return (
     <label className="muted" htmlFor="language-selector">

--- a/src/shared/ui/Layout.tsx
+++ b/src/shared/ui/Layout.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { Link, NavLink, Outlet } from 'react-router-dom'
+import { useThemePreference } from '../hooks/useThemePreference'
 import { LanguageSelector } from './LanguageSelector'
+import { ThemeSelector } from './ThemeSelector'
 
 function navLinkClassName({ isActive }: { isActive: boolean }) {
   return `layout__link${isActive ? ' layout__link--active' : ''}`
@@ -8,6 +10,7 @@ function navLinkClassName({ isActive }: { isActive: boolean }) {
 
 export function Layout() {
   const { t } = useTranslation()
+  const { theme, setTheme } = useThemePreference()
   const year = new Date().getFullYear()
 
   return (
@@ -31,6 +34,7 @@ export function Layout() {
             <NavLink className={navLinkClassName} to="/copyright">
               {t('nav.copyright')}
             </NavLink>
+            <ThemeSelector onThemeChange={setTheme} theme={theme} />
             <LanguageSelector />
           </nav>
         </div>

--- a/src/shared/ui/ThemeSelector.tsx
+++ b/src/shared/ui/ThemeSelector.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next'
+import type { Theme } from '../hooks/useThemePreference'
+
+interface ThemeSelectorProps {
+  theme: Theme
+  onThemeChange: (theme: Theme) => void
+}
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="theme-toggle__icon"
+      fill="none"
+      role="img"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2.5M12 19.5V22M4.93 4.93l1.77 1.77M17.3 17.3l1.77 1.77M2 12h2.5M19.5 12H22M4.93 19.07l1.77-1.77M17.3 6.7l1.77-1.77" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="theme-toggle__icon"
+      fill="currentColor"
+      role="img"
+      viewBox="0 0 24 24"
+    >
+      <path d="M21 14.5A9 9 0 1 1 9.5 3a7 7 0 0 0 11.5 11.5Z" />
+    </svg>
+  )
+}
+
+export function ThemeSelector({ theme, onThemeChange }: ThemeSelectorProps) {
+  const { t } = useTranslation()
+  const nextTheme: Theme = theme === 'light' ? 'dark' : 'light'
+  const toggleLabel = theme === 'light' ? t('theme.switchToDark') : t('theme.switchToLight')
+
+  return (
+    <button
+      aria-label={toggleLabel}
+      aria-pressed={theme === 'dark'}
+      className="theme-toggle"
+      onClick={() => onThemeChange(nextTheme)}
+      title={toggleLabel}
+      type="button"
+    >
+      {theme === 'dark' ? <MoonIcon /> : <SunIcon />}
+    </button>
+  )
+}

--- a/src/shared/ui/ThemeSelector.tsx
+++ b/src/shared/ui/ThemeSelector.tsx
@@ -2,8 +2,8 @@ import { useTranslation } from 'react-i18next'
 import type { Theme } from '../hooks/useThemePreference'
 
 interface ThemeSelectorProps {
-  theme: Theme
-  onThemeChange: (theme: Theme) => void
+  readonly theme: Theme
+  readonly onThemeChange: (theme: Theme) => void
 }
 
 function SunIcon() {


### PR DESCRIPTION
## What

Adds a full light/dark theme system with persistent user preference, replaces the theme selector with a header icon toggle, and persists selected UI language across visits. It also fixes locale normalization so variants like `ko-KR` and `en-US` map correctly during language switching and localized text lookup.

## Why

This addresses Issue #33 by adding dark mode with persistence and improves overall UX by remembering language choice between visits. Locale normalization prevents inconsistent i18n behavior when browser or i18n language codes include region suffixes.

Closes #33

## Checklist

### Required

- [ ] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [ ] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A - none added)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Breaking behavior changes are clearly described in this PR (N/A - no breaking changes)
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header light/dark theme toggle with persistent selection and global application
  * In-app runtime language switcher (en, ko, ja) with normalized, persisted language selection
  * Localized theme labels and a visible theme toggle control in the UI

* **Accessibility**
  * Improved keyboard focus visibility and theme-aware input/error styling

* **Documentation**
  * Added UI preferences section to README and architecture docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->