### PR TITLE
Exclude .github folder from editorial index generation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,7 @@ The frontend consumes a static index with this shape:
   - `excludeFileNames`
   - `excludePathPrefixes`
   - `excludePathPatterns`
+- Current defaults exclude repository-management content such as `README.md`, `LICENSE`, and the `.github/` folder.
 
 ### Stable ID policy
 

--- a/scripts/editorial-index.config.json
+++ b/scripts/editorial-index.config.json
@@ -1,6 +1,6 @@
 {
   "supportedExtensions": [".pdf", ".md", ".txt"],
   "excludeFileNames": ["README.md", "LICENSE"],
-  "excludePathPrefixes": [],
+  "excludePathPrefixes": [".github"],
   "excludePathPatterns": []
 }


### PR DESCRIPTION
## What

- Add `.github` to `excludePathPrefixes` in `scripts/editorial-index.config.json`.
- Update `ARCHITECTURE.md` exclusion policy text to document `.github/` as a default excluded folder.

## Why

Repository-management files under `.github` can match supported editorial extensions and be included in generated index data. This change prevents non-editorial content from being surfaced in the frontend index.

Closes #38

## Checklist

### Required

- [ ] `npm run format:check` passes (currently reports existing repository-wide Prettier warnings)
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable) (N/A)
- [x] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable) (N/A)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable) (N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR (N/A)
- [ ] i18n updates are included for `en`, `ko`, and `ja` where needed (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to clarify how repository management files are handled during indexing.

* **Chores**
  * Adjusted configuration settings for index exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->