### PR TITLE
Add inline PDF viewer for "View" button

### DIFF
--- a/src/app/routes/AppRouter.tsx
+++ b/src/app/routes/AppRouter.tsx
@@ -4,6 +4,7 @@ import { CategoriesPage } from '../../pages/CategoriesPage'
 import { ContributePage } from '../../pages/ContributePage'
 import { CopyrightPage } from '../../pages/CopyrightPage'
 import { EditorialDetailPage } from '../../pages/EditorialDetailPage'
+import { EditorialViewerPage } from '../../pages/EditorialViewerPage'
 import { HomePage } from '../../pages/HomePage'
 import { SearchPage } from '../../pages/SearchPage'
 import { Layout } from '../../shared/ui/Layout'
@@ -17,6 +18,7 @@ export function AppRouter() {
         <Route element={<CategoriesPage />} path="categories" />
         <Route element={<CategoryPage />} path="categories/*" />
         <Route element={<EditorialDetailPage />} path="editorials/:editorialId" />
+        <Route element={<EditorialViewerPage />} path="editorials/:editorialId/view" />
         <Route element={<ContributePage />} path="contribute" />
         <Route element={<CopyrightPage />} path="copyright" />
       </Route>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -445,6 +445,14 @@ a {
   color: var(--color-download-text);
 }
 
+.editorial-viewer {
+  width: 100%;
+  min-height: 78vh;
+  border: 1px solid var(--color-border);
+  border-radius: 0.6rem;
+  background-color: var(--color-surface);
+}
+
 .tag-list {
   display: flex;
   gap: 0.4rem;

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -161,15 +161,15 @@ export function CategoryPage() {
                   <p className="card__meta">{editorial.filename}</p>
                   <p className="card__meta">{editorial.path}</p>
                   <div className="action-links">
-                    <a
+                    <Link
                       aria-label={t('editorial.viewAria', { title: localizedTitle })}
                       className="action-link"
-                      href={links.viewUrl}
                       rel="noreferrer"
                       target="_blank"
+                      to={`/editorials/${editorial.id}/view`}
                     >
                       {t('editorial.view')}
-                    </a>
+                    </Link>
                     <a
                       aria-label={t('editorial.downloadAria', { title: localizedTitle })}
                       className="action-link action-link--secondary"

--- a/src/pages/EditorialDetailPage.tsx
+++ b/src/pages/EditorialDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
@@ -52,15 +52,15 @@ export function EditorialDetailPage() {
       <p className="muted">{`${t('editorial.path')}: ${editorial.path}`}</p>
       <p className="muted">{`${t('editorial.filename')}: ${editorial.filename}`}</p>
       <div className="action-links">
-        <a
+        <Link
           aria-label={t('editorial.viewAria', { title: localizedTitle })}
           className="action-link"
-          href={links.viewUrl}
           rel="noreferrer"
           target="_blank"
+          to={`/editorials/${editorial.id}/view`}
         >
           {t('editorial.view')}
-        </a>
+        </Link>
         <a
           aria-label={t('editorial.downloadAria', { title: localizedTitle })}
           className="action-link action-link--secondary"

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -74,7 +74,7 @@ export function EditorialViewerPage() {
         setPdfError(nextError)
       })
       .finally(() => {
-        window.clearTimeout(timeoutId)
+        globalThis.clearTimeout(timeoutId)
       })
 
     return () => {

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
+import { buildEditorialLinks } from '../shared/api/editorialLinks'
+import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { getLocalizedText } from '../shared/i18n/getLocalizedText'
+
+export function EditorialViewerPage() {
+  const { t, i18n } = useTranslation()
+  const { editorialId } = useParams()
+  const { data, isLoading, error } = useEditorialIndex()
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null)
+  const [pdfError, setPdfError] = useState<Error | null>(null)
+
+  const editorial = useMemo(
+    () => data.editorials.find((item) => item.id === editorialId),
+    [data.editorials, editorialId],
+  )
+
+  useEffect(() => {
+    if (!editorial) {
+      setPdfUrl(null)
+      setPdfError(null)
+      return
+    }
+
+    const links = buildEditorialLinks(editorial.path)
+    let isMounted = true
+    let objectUrl: string | null = null
+
+    setPdfUrl(null)
+    setPdfError(null)
+
+    void fetch(links.downloadUrl)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load PDF. Status: ${response.status}`)
+        }
+
+        const bytes = await response.arrayBuffer()
+        const pdfBlob = new Blob([bytes], { type: 'application/pdf' })
+        objectUrl = URL.createObjectURL(pdfBlob)
+
+        if (!isMounted) {
+          URL.revokeObjectURL(objectUrl)
+          return
+        }
+
+        setPdfUrl(objectUrl)
+      })
+      .catch((fetchError: unknown) => {
+        if (!isMounted) {
+          return
+        }
+
+        const nextError =
+          fetchError instanceof Error
+            ? fetchError
+            : new Error('Unknown error while loading editorial PDF.')
+
+        setPdfError(nextError)
+      })
+
+    return () => {
+      isMounted = false
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [editorial])
+
+  if (isLoading) {
+    return <p className="muted">{t('common.loading')}</p>
+  }
+
+  if (error) {
+    return <p className="error">{error.message}</p>
+  }
+
+  if (!editorial) {
+    return <p className="error">{t('editorial.notFound')}</p>
+  }
+
+  const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
+  const links = buildEditorialLinks(editorial.path)
+
+  return (
+    <article className="page">
+      <h1>{localizedTitle}</h1>
+      <p className="page__description">{t('editorial.viewerDescription')}</p>
+      <p className="muted">{`${t('editorial.path')}: ${editorial.path}`}</p>
+      <div className="action-links">
+        <a
+          aria-label={t('editorial.downloadAria', { title: localizedTitle })}
+          className="action-link action-link--secondary"
+          href={links.downloadUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t('editorial.download')}
+        </a>
+      </div>
+
+      {pdfError && <p className="error">{t('editorial.viewerLoadFailed')}</p>}
+      {!pdfError && !pdfUrl && <p className="muted">{t('editorial.viewerLoading')}</p>}
+
+      {pdfUrl && (
+        <object
+          aria-label={t('editorial.viewAria', { title: localizedTitle })}
+          className="editorial-viewer"
+          data={pdfUrl}
+          type="application/pdf"
+        >
+          <p className="muted">
+            {t('editorial.viewerFallback')}{' '}
+            <a
+              className="action-link action-link--secondary"
+              href={links.downloadUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t('editorial.download')}
+            </a>
+          </p>
+        </object>
+      )}
+    </article>
+  )
+}

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -80,7 +80,7 @@ export function EditorialViewerPage() {
     return () => {
       isMounted = false
       abortController.abort()
-      window.clearTimeout(timeoutId)
+      globalThis.clearTimeout(timeoutId)
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl)
       }

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -29,7 +29,7 @@ export function EditorialViewerPage() {
     let objectUrl: string | null = null
     const abortController = new AbortController()
     let didTimeout = false
-    const timeoutId = window.setTimeout(() => {
+    const timeoutId = globalThis.setTimeout(() => {
       didTimeout = true
       abortController.abort()
     }, 15000)

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -27,11 +27,17 @@ export function EditorialViewerPage() {
     const links = buildEditorialLinks(editorial.path)
     let isMounted = true
     let objectUrl: string | null = null
+    const abortController = new AbortController()
+    let didTimeout = false
+    const timeoutId = window.setTimeout(() => {
+      didTimeout = true
+      abortController.abort()
+    }, 15000)
 
     setPdfUrl(null)
     setPdfError(null)
 
-    void fetch(links.downloadUrl)
+    void fetch(links.downloadUrl, { signal: abortController.signal })
       .then(async (response) => {
         if (!response.ok) {
           throw new Error(`Failed to load PDF. Status: ${response.status}`)
@@ -53,6 +59,13 @@ export function EditorialViewerPage() {
           return
         }
 
+        if (fetchError instanceof DOMException && fetchError.name === 'AbortError') {
+          if (didTimeout) {
+            setPdfError(new Error('Timed out while loading editorial PDF.'))
+          }
+          return
+        }
+
         const nextError =
           fetchError instanceof Error
             ? fetchError
@@ -60,9 +73,14 @@ export function EditorialViewerPage() {
 
         setPdfError(nextError)
       })
+      .finally(() => {
+        window.clearTimeout(timeoutId)
+      })
 
     return () => {
       isMounted = false
+      abortController.abort()
+      window.clearTimeout(timeoutId)
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl)
       }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -150,15 +150,15 @@ export function SearchPage() {
                         <p className="card__meta">{editorial.path}</p>
                       </div>
                       <div className="action-links">
-                        <a
+                        <Link
                           aria-label={t('editorial.viewAria', { title: localizedTitle })}
                           className="action-link"
-                          href={links.viewUrl}
                           rel="noreferrer"
                           target="_blank"
+                          to={`/editorials/${editorial.id}/view`}
                         >
                           {t('editorial.view')}
-                        </a>
+                        </Link>
                         <a
                           aria-label={t('editorial.downloadAria', { title: localizedTitle })}
                           className="action-link action-link--secondary"

--- a/src/shared/api/editorialLinks.ts
+++ b/src/shared/api/editorialLinks.ts
@@ -15,9 +15,9 @@ function encodePath(path: string): string {
 
 export function buildEditorialLinks(path: string) {
   const encodedPath = encodePath(path)
+  const rawFileUrl = `https://raw.githubusercontent.com/${CP_EDITORIAL_DATA_REPOSITORY}/main/${encodedPath}`
 
   return {
-    viewUrl: `https://github.com/${CP_EDITORIAL_DATA_REPOSITORY}/blob/main/${encodedPath}`,
-    downloadUrl: `https://raw.githubusercontent.com/${CP_EDITORIAL_DATA_REPOSITORY}/main/${encodedPath}`,
+    downloadUrl: rawFileUrl,
   }
 }

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -100,6 +100,10 @@ export const resources = {
         viewAria: 'View editorial: {{title}}',
         downloadAria: 'Download editorial: {{title}}',
         notFound: 'Editorial not found.',
+        viewerDescription: 'Preview this editorial PDF directly in your browser.',
+        viewerLoading: 'Preparing PDF viewer...',
+        viewerLoadFailed: 'Unable to load this PDF in the browser viewer.',
+        viewerFallback: 'If preview is not available, use:',
       },
       contribute: {
         heading: 'How to Upload Editorial Data',
@@ -274,6 +278,10 @@ export const resources = {
         viewAria: '{{title}} 에디토리얼 열기',
         downloadAria: '{{title}} 에디토리얼 다운로드',
         notFound: '에디토리얼을 찾을 수 없습니다.',
+        viewerDescription: '브라우저에서 이 에디토리얼 PDF를 바로 볼 수 있습니다.',
+        viewerLoading: 'PDF 뷰어를 준비하는 중입니다...',
+        viewerLoadFailed: '브라우저 뷰어에서 이 PDF를 불러오지 못했습니다.',
+        viewerFallback: '미리보기가 불가능하면 다음을 사용하세요:',
       },
       contribute: {
         heading: '에디토리얼 데이터 업로드 방법',
@@ -445,6 +453,10 @@ export const resources = {
         viewAria: '{{title}} のエディトリアルを表示',
         downloadAria: '{{title}} のエディトリアルをダウンロード',
         notFound: 'エディトリアルが見つかりません。',
+        viewerDescription: 'このエディトリアル PDF をブラウザで直接表示します。',
+        viewerLoading: 'PDF ビューアーを準備しています...',
+        viewerLoadFailed: 'ブラウザビューアーでこの PDF を読み込めませんでした。',
+        viewerFallback: 'プレビューできない場合は次を使用してください:',
       },
       contribute: {
         heading: 'エディトリアルデータのアップロード方法',


### PR DESCRIPTION
## What

- Added a dedicated in-app PDF viewer page at `/editorials/:editorialId/view` and registered a new route for it.
- Updated all `View` actions (category, search, detail pages) to open the viewer route in a new tab.
- Kept `Download` as the raw file action and simplified `buildEditorialLinks()` to return only `downloadUrl`.
- Added viewer UI styling and i18n strings for `en`, `ko`, and `ja`.

## Why

The previous `View` behavior used a raw GitHub URL. In practice this often triggered file download or external Acrobat launch instead of stable browser viewing. This change ensures `View` consistently opens an inline browser preview while preserving explicit download behavior.

Closes #68.

## Checklist

### Required

- [ ] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [x] Search/filter/navigation behavior was verified for this change (if applicable)
- [ ] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editorial Viewer page for in-app PDF preview with download links.

* **Improvements**
  * “View” actions now use internal navigation and open the viewer in a new tab.
  * Viewer layout styled for full-width display and improved presentation.
  * Added localized strings (en/ko/ja) for viewer states: loading, errors, and fallback instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/cp-editorial-frontend/pull/70)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->