### PR TITLE
Support Open Graph for generating cards

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -158,6 +158,8 @@ Category browsing is path-hierarchy driven, so nested folders like
 - Theme supports `light` and `dark`.
 - Active theme is selected in the header and persisted in browser local storage.
 - Theme is applied at the document root via `data-theme`, so all routed pages share one consistent palette.
+- Open Graph/Twitter metadata has static defaults in `index.html` and `public/404.html`, then route-level values are updated client-side in the SPA.
+- Due to static hosting constraints, non-JS crawlers may still consume the default metadata rather than route-specific values.
 
 ## 8. Upload guidance flow
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm run build
 
 - Theme: switch between light and dark mode from the header; the selected mode is saved in local storage.
 - Language: switch UI language at runtime (`en`, `ko`, `ja`); the selected language is also saved in local storage.
+- Social previews: Open Graph/Twitter metadata is provided with static defaults and client-side route updates for richer link cards.
 
 ## The way the system works
 

--- a/index.html
+++ b/index.html
@@ -5,8 +5,30 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico?v=8eac82ad" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=8eac82ad" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=8eac82ad" />
+    <link rel="canonical" href="https://editorial.coduck.io/" />
     <meta name="theme-color" content="#271909" />
+    <meta
+      name="description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Coduck - CP Editorial" />
+    <meta property="og:title" content="Coduck - CP Editorial" />
+    <meta
+      property="og:description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
+    <meta property="og:url" content="https://editorial.coduck.io/" />
+    <meta property="og:image" content="https://editorial.coduck.io/images/editorial-home.png" />
+    <meta property="og:image:alt" content="Coduck - CP Editorial preview image" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Coduck - CP Editorial" />
+    <meta
+      name="twitter:description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
+    <meta name="twitter:image" content="https://editorial.coduck.io/images/editorial-home.png" />
     <title>Coduck - CP Editorial</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Coduck - CP Editorial" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="Coduck - CP Editorial" />
     <meta
       property="og:description"

--- a/public/404.html
+++ b/public/404.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Coduck - CP Editorial" />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:title" content="Coduck - CP Editorial" />
     <meta
       property="og:description"

--- a/public/404.html
+++ b/public/404.html
@@ -2,7 +2,29 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="canonical" href="https://editorial.coduck.io/" />
+    <meta
+      name="description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Coduck - CP Editorial" />
+    <meta property="og:title" content="Coduck - CP Editorial" />
+    <meta
+      property="og:description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
+    <meta property="og:url" content="https://editorial.coduck.io/" />
+    <meta property="og:image" content="https://editorial.coduck.io/images/editorial-home.png" />
+    <meta property="og:image:alt" content="Coduck - CP Editorial preview image" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Coduck - CP Editorial" />
+    <meta
+      name="twitter:description"
+      content="A curated archive for competitive-programming contest editorials."
+    />
+    <meta name="twitter:image" content="https://editorial.coduck.io/images/editorial-home.png" />
     <title>Coduck - CP Editorial</title>
   </head>
   <body>

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { EditorialRecord } from '../entities/editorial/model/types'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
 function categoriesWithCount(editorials: EditorialRecord[]) {
   const countMap = new Map<string, number>()
@@ -15,8 +16,14 @@ function categoriesWithCount(editorials: EditorialRecord[]) {
 }
 
 export function CategoriesPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
+
+  usePageMetadata({
+    title: `${t('categories.heading')} | ${t('appTitle')}`,
+    description: t('footer.description'),
+    locale: i18n.resolvedLanguage,
+  })
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -4,6 +4,7 @@ import { Link, Navigate, useParams } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
 
 function decodePathSegment(value: string): string {
@@ -87,6 +88,24 @@ export function CategoryPage() {
     }
   }, [data.editorials, selectedSegments])
 
+  const currentSegment = selectedSegments[selectedSegments.length - 1] ?? t('category.unknown')
+  const isLeafNode = childNodes.length === 0
+  const heading = isLeafNode
+    ? t('contest.heading', { contest: currentSegment })
+    : t('category.heading', { category: currentSegment })
+
+  usePageMetadata({
+    title:
+      selectedSegments.length > 0
+        ? `${heading} | ${t('appTitle')}`
+        : `${t('categories.heading')} | ${t('appTitle')}`,
+    description:
+      selectedSegments.length > 0
+        ? `${t('categories.heading')}: ${selectedSegments.join(' > ')}`
+        : t('footer.description'),
+    locale: i18n.resolvedLanguage,
+  })
+
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>
   }
@@ -102,12 +121,6 @@ export function CategoryPage() {
   if (!hasMatches) {
     return <p className="muted">{t('contest.empty')}</p>
   }
-
-  const currentSegment = selectedSegments[selectedSegments.length - 1] ?? t('category.unknown')
-  const isLeafNode = childNodes.length === 0
-  const heading = isLeafNode
-    ? t('contest.heading', { contest: currentSegment })
-    : t('category.heading', { category: currentSegment })
 
   return (
     <section className="page">

--- a/src/pages/ContributePage.tsx
+++ b/src/pages/ContributePage.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
 function renderBacktickBold(text: string) {
   const segments = text.split(/`([^`]+)`/g)
@@ -14,7 +15,13 @@ function renderBacktickBold(text: string) {
 }
 
 export function ContributePage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+
+  usePageMetadata({
+    title: `${t('contribute.heading')} | ${t('appTitle')}`,
+    description: t('contribute.footer'),
+    locale: i18n.resolvedLanguage,
+  })
 
   return (
     <section className="page">

--- a/src/pages/CopyrightPage.tsx
+++ b/src/pages/CopyrightPage.tsx
@@ -1,7 +1,14 @@
 import { Trans, useTranslation } from 'react-i18next'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
 export function CopyrightPage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+
+  usePageMetadata({
+    title: `${t('copyrightPage.heading')} | ${t('appTitle')}`,
+    description: t('copyrightPage.description'),
+    locale: i18n.resolvedLanguage,
+  })
 
   return (
     <section className="page">

--- a/src/pages/EditorialDetailPage.tsx
+++ b/src/pages/EditorialDetailPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
 
 export function EditorialDetailPage() {
@@ -14,6 +15,21 @@ export function EditorialDetailPage() {
     () => data.editorials.find((item) => item.id === editorialId),
     [data.editorials, editorialId],
   )
+
+  const appTitle = t('appTitle')
+  const localizedTitle = editorial
+    ? getLocalizedText(editorial.title, i18n.resolvedLanguage)
+    : appTitle
+  const metadataDescription = editorial
+    ? getLocalizedText(editorial.summary, i18n.resolvedLanguage)
+    : t('editorial.notFound')
+
+  usePageMetadata({
+    title: editorial ? `${localizedTitle} | ${appTitle}` : appTitle,
+    description: metadataDescription,
+    locale: i18n.resolvedLanguage,
+    type: editorial ? 'article' : 'website',
+  })
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>
@@ -28,7 +44,6 @@ export function EditorialDetailPage() {
   }
 
   const links = buildEditorialLinks(editorial.path)
-  const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
   const categoryLabel = editorial.categories.length > 0 ? editorial.categories.join(', ') : '-'
 
   return (

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
 
 export function EditorialViewerPage() {
@@ -16,6 +17,23 @@ export function EditorialViewerPage() {
     () => data.editorials.find((item) => item.id === editorialId),
     [data.editorials, editorialId],
   )
+
+  const appTitle = t('appTitle')
+  const localizedTitle = editorial
+    ? getLocalizedText(editorial.title, i18n.resolvedLanguage)
+    : appTitle
+  const metadataDescription = editorial
+    ? getLocalizedText(editorial.summary, i18n.resolvedLanguage)
+    : t('editorial.viewerDescription')
+
+  usePageMetadata({
+    title: editorial
+      ? `${localizedTitle} (${t('editorial.view')}) | ${appTitle}`
+      : `${t('editorial.view')} | ${appTitle}`,
+    description: metadataDescription,
+    locale: i18n.resolvedLanguage,
+    type: editorial ? 'article' : 'website',
+  })
 
   useEffect(() => {
     if (!editorial) {
@@ -99,7 +117,6 @@ export function EditorialViewerPage() {
     return <p className="error">{t('editorial.notFound')}</p>
   }
 
-  const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
   const links = buildEditorialLinks(editorial.path)
 
   return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,9 +1,16 @@
 import { Trans, useTranslation } from 'react-i18next'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
 export function HomePage() {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
+
+  usePageMetadata({
+    title: t('appTitle'),
+    description: t('home.description'),
+    locale: i18n.resolvedLanguage,
+  })
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
+import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
 
 interface ContestResult {
@@ -87,6 +88,12 @@ export function SearchPage() {
   const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
   const [query, setQuery] = useState('')
+
+  usePageMetadata({
+    title: `${t('search.heading')} | ${t('appTitle')}`,
+    description: t('search.description'),
+    locale: i18n.resolvedLanguage,
+  })
 
   const contestResults = useMemo(() => {
     const grouped = groupByContest(data.editorials)

--- a/src/shared/hooks/usePageMetadata.ts
+++ b/src/shared/hooks/usePageMetadata.ts
@@ -62,9 +62,7 @@ export function usePageMetadata({
   type = 'website',
 }: PageMetadata) {
   useEffect(() => {
-    const pageUrl = toAbsoluteUrl(
-      `${globalThis.location.pathname}${globalThis.location.search}`,
-    )
+    const pageUrl = toAbsoluteUrl(`${globalThis.location.pathname}${globalThis.location.search}`)
     const ogLocale = normalizeLocale(locale)
     const resolvedImageUrl = toAbsoluteUrl(imageUrl)
 

--- a/src/shared/hooks/usePageMetadata.ts
+++ b/src/shared/hooks/usePageMetadata.ts
@@ -62,7 +62,9 @@ export function usePageMetadata({
   type = 'website',
 }: PageMetadata) {
   useEffect(() => {
-    const pageUrl = toAbsoluteUrl(`${globalThis.location.pathname}${window.location.search}`)
+    const pageUrl = toAbsoluteUrl(
+      `${globalThis.location.pathname}${globalThis.location.search}`,
+    )
     const ogLocale = normalizeLocale(locale)
     const resolvedImageUrl = toAbsoluteUrl(imageUrl)
 

--- a/src/shared/hooks/usePageMetadata.ts
+++ b/src/shared/hooks/usePageMetadata.ts
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+
+interface PageMetadata {
+  title: string
+  description: string
+  imageUrl?: string
+  locale?: string
+  type?: 'website' | 'article'
+}
+
+const SITE_URL = 'https://editorial.coduck.io'
+const DEFAULT_IMAGE_URL = `${SITE_URL}/images/editorial-home.png`
+
+function toAbsoluteUrl(value: string): string {
+  return new URL(value, SITE_URL).toString()
+}
+
+function normalizeLocale(value: string | undefined): string {
+  if (!value) {
+    return 'en_US'
+  }
+
+  const base = value.split('-')[0]?.toLowerCase()
+  if (base === 'ko') {
+    return 'ko_KR'
+  }
+  if (base === 'ja') {
+    return 'ja_JP'
+  }
+
+  return 'en_US'
+}
+
+function setMetaTag(attribute: 'name' | 'property', key: string, content: string) {
+  const selector = `meta[${attribute}="${key}"]`
+  let element = document.head.querySelector<HTMLMetaElement>(selector)
+  if (!element) {
+    element = document.createElement('meta')
+    element.setAttribute(attribute, key)
+    document.head.appendChild(element)
+  }
+
+  element.setAttribute('content', content)
+}
+
+function setCanonicalLink(href: string) {
+  let element = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+  if (!element) {
+    element = document.createElement('link')
+    element.setAttribute('rel', 'canonical')
+    document.head.appendChild(element)
+  }
+
+  element.setAttribute('href', href)
+}
+
+export function usePageMetadata({
+  title,
+  description,
+  imageUrl = DEFAULT_IMAGE_URL,
+  locale,
+  type = 'website',
+}: PageMetadata) {
+  useEffect(() => {
+    const pageUrl = toAbsoluteUrl(`${window.location.pathname}${window.location.search}`)
+    const ogLocale = normalizeLocale(locale)
+    const resolvedImageUrl = toAbsoluteUrl(imageUrl)
+
+    document.title = title
+    setCanonicalLink(pageUrl)
+    setMetaTag('name', 'description', description)
+    setMetaTag('property', 'og:type', type)
+    setMetaTag('property', 'og:site_name', 'Coduck - CP Editorial')
+    setMetaTag('property', 'og:title', title)
+    setMetaTag('property', 'og:description', description)
+    setMetaTag('property', 'og:url', pageUrl)
+    setMetaTag('property', 'og:image', resolvedImageUrl)
+    setMetaTag('property', 'og:image:alt', 'Coduck - CP Editorial preview image')
+    setMetaTag('property', 'og:locale', ogLocale)
+    setMetaTag('name', 'twitter:card', 'summary_large_image')
+    setMetaTag('name', 'twitter:title', title)
+    setMetaTag('name', 'twitter:description', description)
+    setMetaTag('name', 'twitter:image', resolvedImageUrl)
+  }, [description, imageUrl, locale, title, type])
+}

--- a/src/shared/hooks/usePageMetadata.ts
+++ b/src/shared/hooks/usePageMetadata.ts
@@ -62,7 +62,7 @@ export function usePageMetadata({
   type = 'website',
 }: PageMetadata) {
   useEffect(() => {
-    const pageUrl = toAbsoluteUrl(`${window.location.pathname}${window.location.search}`)
+    const pageUrl = toAbsoluteUrl(`${globalThis.location.pathname}${window.location.search}`)
     const ogLocale = normalizeLocale(locale)
     const resolvedImageUrl = toAbsoluteUrl(imageUrl)
 


### PR DESCRIPTION
## What

- Add static Open Graph and Twitter card defaults in `index.html` and `public/404.html` for baseline crawler coverage.
- Add a shared `usePageMetadata` hook to update title, canonical URL, description, `og:*`, and `twitter:*` tags client-side.
- Apply route-level metadata across core pages and editorial pages, including localized editorial title/summary metadata on detail and viewer routes.
- Document social metadata behavior and static-hosting limitations in `README.md` and `ARCHITECTURE.md`.

## Why

Shared links currently do not have robust social metadata, so cards are inconsistent or missing. This change adds reliable static defaults and route-aware client-side updates without expanding scope to prerender/SSR.

Closes #84.

## Checklist

### Required

- [ ] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [ ] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [ ] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-route page metadata now update client-side so each page sets its title, description, locale and preview image for richer link previews.

* **SEO / Social**
  * Added canonical links and expanded Open Graph/Twitter meta tags across the site to improve link cards and sharing.

* **Documentation**
  * Docs updated to explain the metadata strategy, static defaults for non-JS crawlers, and social preview behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/cp-editorial-frontend/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->