### PR TITLE
Improve the home page with a primary search or browse entry point

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -481,6 +481,83 @@ a {
   gap: 0.9rem;
 }
 
+.home-entry {
+  width: min(720px, 100%);
+  display: grid;
+  gap: 0.7rem;
+}
+
+.home-entry__search {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.home-entry__label {
+  color: var(--color-muted);
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.home-entry__controls {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: var(--color-surface);
+  background-color: color-mix(
+    in srgb,
+    var(--color-surface) 88%,
+    var(--color-surface-container-low)
+  );
+  box-shadow: var(--elevation-2);
+  padding: 0.65rem;
+  display: flex;
+  gap: 0.6rem;
+  align-items: stretch;
+}
+
+.home-entry__input {
+  flex: 1 1 240px;
+  width: 100%;
+}
+
+.home-entry__button,
+.home-entry__link {
+  border-radius: 999px;
+  min-height: 3rem;
+  padding: 0.7rem 1rem;
+  font: inherit;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  cursor: pointer;
+}
+
+.home-entry__button {
+  border: 1px solid var(--color-primary-strong);
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+  box-shadow: var(--elevation-1);
+}
+
+.home-entry__button:hover {
+  background-color: var(--color-primary-strong);
+  box-shadow: var(--elevation-2);
+}
+
+.home-entry__link {
+  width: fit-content;
+  border: 1px solid var(--color-download-border);
+  background-color: var(--color-download-bg);
+  color: var(--color-download-text);
+  box-shadow: var(--elevation-1);
+}
+
+.home-entry__link:hover {
+  box-shadow: var(--elevation-2);
+  filter: saturate(1.08);
+}
+
 .home-dashboard__stats {
   grid-column: 1 / -1;
 }
@@ -701,6 +778,8 @@ a {
 @media (prefers-reduced-motion: reduce) {
   .card,
   .action-link,
+  .home-entry__button,
+  .home-entry__link,
   .theme-toggle {
     transition: none;
   }
@@ -710,6 +789,7 @@ a {
   }
 
   .action-link:hover,
+  .home-entry__link:hover,
   .theme-toggle:hover {
     filter: none;
   }
@@ -722,6 +802,8 @@ a {
 .card__title:focus-visible,
 .competition-editorials__title:focus-visible,
 .action-link:focus-visible,
+.home-entry__button:focus-visible,
+.home-entry__link:focus-visible,
 .input:focus-visible,
 .language-selector:focus-visible,
 .theme-toggle:focus-visible {
@@ -759,6 +841,15 @@ a {
 
   .home-hero-icon-wrap {
     min-height: 12rem;
+  }
+
+  .home-entry__controls {
+    display: grid;
+  }
+
+  .home-entry__button,
+  .home-entry__link {
+    width: 100%;
   }
 
   .competition-editorials__item {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,16 +1,27 @@
+import { type FormEvent, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
+import { Link, useNavigate } from 'react-router-dom'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
 export function HomePage() {
   const { t, i18n } = useTranslation()
+  const navigate = useNavigate()
   const { data, isLoading, error } = useEditorialIndex()
+  const [query, setQuery] = useState('')
 
   usePageMetadata({
     title: t('appTitle'),
     description: t('home.description'),
     locale: i18n.resolvedLanguage,
   })
+
+  function handleSearchSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const normalizedQuery = query.trim()
+    void navigate(normalizedQuery ? `/search?q=${encodeURIComponent(normalizedQuery)}` : '/search')
+  }
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>
@@ -28,6 +39,29 @@ export function HomePage() {
         <div className="home-dashboard__intro">
           <h1>{t('home.heading')}</h1>
           <p className="page__description">{t('home.description')}</p>
+
+          <div className="home-entry">
+            <form className="home-entry__search" onSubmit={handleSearchSubmit}>
+              <label className="home-entry__label" htmlFor="home-search-input">
+                {t('home.entry.label')}
+              </label>
+              <div className="home-entry__controls">
+                <input
+                  className="input home-entry__input"
+                  id="home-search-input"
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder={t('home.entry.placeholder')}
+                  value={query}
+                />
+                <button className="home-entry__button" type="submit">
+                  {t('home.entry.submit')}
+                </button>
+              </div>
+            </form>
+            <Link className="home-entry__link" to="/categories">
+              {t('home.entry.browseCategories')}
+            </Link>
+          </div>
         </div>
 
         <div className="home-hero-icon-wrap">

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
@@ -87,7 +87,9 @@ function filterContestResults(
 export function SearchPage() {
   const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
-  const [query, setQuery] = useState('')
+  const [searchParams] = useSearchParams()
+  const urlQuery = searchParams.get('q') ?? ''
+  const [query, setQuery] = useState(urlQuery)
 
   usePageMetadata({
     title: `${t('search.heading')} | ${t('appTitle')}`,
@@ -99,6 +101,10 @@ export function SearchPage() {
     const grouped = groupByContest(data.editorials)
     return filterContestResults(grouped, query, i18n.resolvedLanguage)
   }, [data.editorials, i18n.resolvedLanguage, query])
+
+  useEffect(() => {
+    setQuery(urlQuery)
+  }, [urlQuery])
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -38,6 +38,12 @@ export const resources = {
       home: {
         heading: 'Find Contest Editorials',
         description: 'Search competitions and quickly open or download editorials by keyword.',
+        entry: {
+          label: 'Start with a keyword',
+          placeholder: 'Try ICPC, Codeforces, 2024...',
+          submit: 'Search',
+          browseCategories: 'Browse categories',
+        },
         stats: {
           editorials: 'Editorials',
           contests: 'Competitions',
@@ -218,6 +224,12 @@ export const resources = {
         heading: '대회 에디토리얼 찾기',
         description:
           '대회 이름 키워드로 원하는 대회를 찾아 해설을 열람하거나 다운로드할 수 있습니다.',
+        entry: {
+          label: '키워드로 바로 시작하기',
+          placeholder: 'ICPC, Codeforces, 2024 등을 입력해 보세요...',
+          submit: '검색',
+          browseCategories: '카테고리 보기',
+        },
         stats: {
           editorials: '에디토리얼 수',
           contests: '대회 수',
@@ -392,6 +404,12 @@ export const resources = {
         heading: '大会エディトリアルを探す',
         description:
           '大会名のキーワードで大会を見つけ、エディトリアルを表示・ダウンロードできます。',
+        entry: {
+          label: 'キーワードから始める',
+          placeholder: 'ICPC、Codeforces、2024 など...',
+          submit: '検索',
+          browseCategories: 'カテゴリを見る',
+        },
         stats: {
           editorials: 'エディトリアル数',
           contests: '大会数',


### PR DESCRIPTION
## What

Add a primary discovery entry point to the home hero with a keyword search form and a category browsing CTA. The search page now accepts `?q=` so home searches open directly into filtered results.

Closes #108.

## Why

Users should be able to start finding editorials from the home page without returning to the header navigation.

## Checklist

### Required

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [x] Search/filter/navigation behavior was verified for this change (if applicable)
- [x] Editorial index generation impact was verified (not applicable; no index generation changes)
- [x] I added or updated tests for changed behavior (not applicable; covered by existing checks and browser validation)

### Configuration & Docs

- [x] User-facing docs were updated (not applicable; no docs behavior changed)
- [x] New dependencies/configuration are documented (not applicable; no new dependencies/configuration)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Breaking behavior changes are clearly described in this PR (not applicable; no breaking changes)
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a search form to the home page enabling quick access to search functionality.
  * Search results are now synchronized with URL query parameters for bookmarkable and shareable searches.
  * Extended localization support to include Korean and Japanese for the search interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->