### PR TITLE
Avoid showing every search result before the user enters a query

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -129,16 +129,16 @@ Normalization rejects invalid index data (missing required fields or empty local
 
 ## 5. Routing model
 
-| Route                           | Purpose                                                              |
-| ------------------------------- | -------------------------------------------------------------------- |
-| `/`                             | Home summary, index stats, and “What is CP Editorial?” article       |
-| `/search`                       | Keyword search grouped by category + contest, then editorial entries |
-| `/categories`                   | Category listing                                                     |
-| `/categories/*`                 | Hierarchical browse pages for each directory level                   |
-| `/editorials/:editorialId`      | Editorial detail page                                                |
-| `/editorials/:editorialId/view` | Inline PDF viewer for editorial content                              |
-| `/contribute`                   | Upload/contribution guide for `cp-editorial-data`                    |
-| `/copyright`                    | Ownership, attribution, and usage guidance                           |
+| Route                           | Purpose                                                         |
+| ------------------------------- | --------------------------------------------------------------- |
+| `/`                             | Home summary, index stats, and “What is CP Editorial?” article  |
+| `/search`                       | Empty-search summaries, then keyword results grouped by contest |
+| `/categories`                   | Category listing                                                |
+| `/categories/*`                 | Hierarchical browse pages for each directory level              |
+| `/editorials/:editorialId`      | Editorial detail page                                           |
+| `/editorials/:editorialId/view` | Inline PDF viewer for editorial content                         |
+| `/contribute`                   | Upload/contribution guide for `cp-editorial-data`               |
+| `/copyright`                    | Ownership, attribution, and usage guidance                      |
 
 Category browsing is path-hierarchy driven, so nested folders like
 `ICPC/Regionals/Asia Pacific/Asia Pacific Championship` are navigable at each level.

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -662,6 +662,60 @@ a {
   text-underline-offset: 0.22em;
 }
 
+.search-start {
+  display: grid;
+  gap: 1rem;
+}
+
+.search-start__body {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: var(--color-surface);
+  box-shadow: 0 1px 0 rgb(0 0 0 / 0.04);
+  padding: 1.05rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.search-start__heading {
+  margin: 0 0 0.3rem;
+  color: var(--color-primary-strong);
+  font-size: 1.2rem;
+  line-height: 1.3;
+}
+
+.search-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.7rem;
+}
+
+.search-summary {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: var(--color-surface-container-low);
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.search-summary__title {
+  color: var(--color-primary-strong);
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.search-summary__title:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.22em;
+}
+
 .action-links {
   display: flex;
   gap: 0.45rem;
@@ -801,6 +855,7 @@ a {
 .layout__footer-external:focus-visible,
 .card__title:focus-visible,
 .competition-editorials__title:focus-visible,
+.search-summary__title:focus-visible,
 .action-link:focus-visible,
 .home-entry__button:focus-visible,
 .home-entry__link:focus-visible,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -19,6 +19,9 @@ interface CategorySummary {
   editorialCount: number
 }
 
+/**
+ * Checks every searchable editorial field, including localized text, against a normalized query.
+ */
 function matchesEditorialKeywords(
   editorial: EditorialRecord,
   query: string,
@@ -38,6 +41,9 @@ function matchesEditorialKeywords(
   return text.includes(query.toLowerCase())
 }
 
+/**
+ * Groups editorials by their top-level category and contest for stable search result sections.
+ */
 function groupByContest(editorials: EditorialRecord[]): ContestResult[] {
   const groups = new Map<string, ContestResult>()
 
@@ -70,6 +76,9 @@ function groupByContest(editorials: EditorialRecord[]): ContestResult[] {
     }))
 }
 
+/**
+ * Builds the category totals shown before a user enters a search query.
+ */
 function summarizeByCategory(contestResults: ContestResult[]): CategorySummary[] {
   const summaries = new Map<string, CategorySummary>()
 
@@ -93,6 +102,9 @@ function summarizeByCategory(contestResults: ContestResult[]): CategorySummary[]
   )
 }
 
+/**
+ * Returns matching contest groups while leaving empty-query display to the summary state.
+ */
 function filterContestResults(
   contestResults: ContestResult[],
   query: string,
@@ -113,6 +125,9 @@ function filterContestResults(
     .filter((result) => result.editorials.length > 0)
 }
 
+/**
+ * Route-level search experience with separate empty-query summaries and keyword results.
+ */
 export function SearchPage() {
   const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -13,6 +13,12 @@ interface ContestResult {
   editorials: EditorialRecord[]
 }
 
+interface CategorySummary {
+  category: string
+  contestCount: number
+  editorialCount: number
+}
+
 function matchesEditorialKeywords(
   editorial: EditorialRecord,
   query: string,
@@ -64,6 +70,29 @@ function groupByContest(editorials: EditorialRecord[]): ContestResult[] {
     }))
 }
 
+function summarizeByCategory(contestResults: ContestResult[]): CategorySummary[] {
+  const summaries = new Map<string, CategorySummary>()
+
+  contestResults.forEach((result) => {
+    const currentSummary = summaries.get(result.category)
+    if (!currentSummary) {
+      summaries.set(result.category, {
+        category: result.category,
+        contestCount: 1,
+        editorialCount: result.editorials.length,
+      })
+      return
+    }
+
+    currentSummary.contestCount += 1
+    currentSummary.editorialCount += result.editorials.length
+  })
+
+  return Array.from(summaries.values()).sort((left, right) =>
+    left.category.localeCompare(right.category),
+  )
+}
+
 function filterContestResults(
   contestResults: ContestResult[],
   query: string,
@@ -71,7 +100,7 @@ function filterContestResults(
 ): ContestResult[] {
   const normalizedQuery = query.trim().toLowerCase()
   if (normalizedQuery.length === 0) {
-    return contestResults
+    return []
   }
 
   return contestResults
@@ -90,6 +119,8 @@ export function SearchPage() {
   const [searchParams] = useSearchParams()
   const urlQuery = searchParams.get('q') ?? ''
   const [query, setQuery] = useState(urlQuery)
+  const normalizedQuery = query.trim()
+  const isEmptySearch = normalizedQuery.length === 0
 
   usePageMetadata({
     title: `${t('search.heading')} | ${t('appTitle')}`,
@@ -97,10 +128,17 @@ export function SearchPage() {
     locale: i18n.resolvedLanguage,
   })
 
-  const contestResults = useMemo(() => {
-    const grouped = groupByContest(data.editorials)
-    return filterContestResults(grouped, query, i18n.resolvedLanguage)
-  }, [data.editorials, i18n.resolvedLanguage, query])
+  const allContestResults = useMemo(() => groupByContest(data.editorials), [data.editorials])
+
+  const contestResults = useMemo(
+    () => filterContestResults(allContestResults, query, i18n.resolvedLanguage),
+    [allContestResults, i18n.resolvedLanguage, query],
+  )
+
+  const categorySummaries = useMemo(
+    () => summarizeByCategory(allContestResults),
+    [allContestResults],
+  )
 
   useEffect(() => {
     setQuery(urlQuery)
@@ -132,65 +170,109 @@ export function SearchPage() {
           />
         </div>
       </div>
-      <p className="muted">{t('search.contestCount', { count: contestResults.length })}</p>
+      {isEmptySearch ? (
+        <div className="search-start">
+          <div className="stats-grid">
+            <div className="stat-card">
+              <p className="stat-card__label">{t('search.start.categories')}</p>
+              <p className="stat-card__value">{categorySummaries.length}</p>
+            </div>
+            <div className="stat-card">
+              <p className="stat-card__label">{t('search.start.competitions')}</p>
+              <p className="stat-card__value">{allContestResults.length}</p>
+            </div>
+            <div className="stat-card">
+              <p className="stat-card__label">{t('search.start.editorials')}</p>
+              <p className="stat-card__value">{data.editorials.length}</p>
+            </div>
+          </div>
 
-      {contestResults.length === 0 ? (
+          <div className="search-start__body">
+            <div>
+              <h2 className="search-start__heading">{t('search.start.heading')}</h2>
+              <p className="muted">{t('search.start.description')}</p>
+            </div>
+
+            <ul className="search-summary-list">
+              {categorySummaries.map((summary) => (
+                <li className="search-summary" key={summary.category}>
+                  <Link
+                    className="search-summary__title"
+                    to={`/categories/${encodeURIComponent(summary.category)}`}
+                  >
+                    {summary.category}
+                  </Link>
+                  <p className="card__meta">
+                    {`${t('search.start.competitionCount', {
+                      count: summary.contestCount,
+                    })} · ${t('search.editorialCount', { count: summary.editorialCount })}`}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : contestResults.length === 0 ? (
         <p className="muted">{t('search.empty')}</p>
       ) : (
-        <ul className="card-list">
-          {contestResults.map((result) => (
-            <li className="card" key={`${result.category}::${result.contest}`}>
-              <div className="card__header">
-                <p className="card__meta">{result.category}</p>
-                <h2 className="card__title">{result.contest}</h2>
-                <p className="card__meta">
-                  {t('search.editorialCount', { count: result.editorials.length })}
-                </p>
-              </div>
+        <>
+          <p className="muted">{t('search.contestCount', { count: contestResults.length })}</p>
 
-              <ul className="competition-editorials">
-                {result.editorials.map((editorial) => {
-                  const links = buildEditorialLinks(editorial.path)
-                  const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
+          <ul className="card-list">
+            {contestResults.map((result) => (
+              <li className="card" key={`${result.category}::${result.contest}`}>
+                <div className="card__header">
+                  <p className="card__meta">{result.category}</p>
+                  <h2 className="card__title">{result.contest}</h2>
+                  <p className="card__meta">
+                    {t('search.editorialCount', { count: result.editorials.length })}
+                  </p>
+                </div>
 
-                  return (
-                    <li className="competition-editorials__item" key={editorial.id}>
-                      <div className="competition-editorials__main">
-                        <Link
-                          className="competition-editorials__title"
-                          to={`/editorials/${editorial.id}`}
-                        >
-                          {localizedTitle}
-                        </Link>
-                        <p className="card__meta">{editorial.path}</p>
-                      </div>
-                      <div className="action-links">
-                        <Link
-                          aria-label={t('editorial.viewAria', { title: localizedTitle })}
-                          className="action-link"
-                          rel="noreferrer"
-                          target="_blank"
-                          to={`/editorials/${editorial.id}/view`}
-                        >
-                          {t('editorial.view')}
-                        </Link>
-                        <a
-                          aria-label={t('editorial.downloadAria', { title: localizedTitle })}
-                          className="action-link action-link--secondary"
-                          href={links.downloadUrl}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          {t('editorial.download')}
-                        </a>
-                      </div>
-                    </li>
-                  )
-                })}
-              </ul>
-            </li>
-          ))}
-        </ul>
+                <ul className="competition-editorials">
+                  {result.editorials.map((editorial) => {
+                    const links = buildEditorialLinks(editorial.path)
+                    const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
+
+                    return (
+                      <li className="competition-editorials__item" key={editorial.id}>
+                        <div className="competition-editorials__main">
+                          <Link
+                            className="competition-editorials__title"
+                            to={`/editorials/${editorial.id}`}
+                          >
+                            {localizedTitle}
+                          </Link>
+                          <p className="card__meta">{editorial.path}</p>
+                        </div>
+                        <div className="action-links">
+                          <Link
+                            aria-label={t('editorial.viewAria', { title: localizedTitle })}
+                            className="action-link"
+                            rel="noreferrer"
+                            target="_blank"
+                            to={`/editorials/${editorial.id}/view`}
+                          >
+                            {t('editorial.view')}
+                          </Link>
+                          <a
+                            aria-label={t('editorial.downloadAria', { title: localizedTitle })}
+                            className="action-link action-link--secondary"
+                            href={links.downloadUrl}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            {t('editorial.download')}
+                          </a>
+                        </div>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
     </section>
   )

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
@@ -152,6 +152,116 @@ export function SearchPage() {
     return <p className="error">{error.message}</p>
   }
 
+  let resultsContent: ReactNode
+  if (isEmptySearch) {
+    resultsContent = (
+      <div className="search-start">
+        <div className="stats-grid">
+          <div className="stat-card">
+            <p className="stat-card__label">{t('search.start.categories')}</p>
+            <p className="stat-card__value">{categorySummaries.length}</p>
+          </div>
+          <div className="stat-card">
+            <p className="stat-card__label">{t('search.start.competitions')}</p>
+            <p className="stat-card__value">{allContestResults.length}</p>
+          </div>
+          <div className="stat-card">
+            <p className="stat-card__label">{t('search.start.editorials')}</p>
+            <p className="stat-card__value">{data.editorials.length}</p>
+          </div>
+        </div>
+
+        <div className="search-start__body">
+          <div>
+            <h2 className="search-start__heading">{t('search.start.heading')}</h2>
+            <p className="muted">{t('search.start.description')}</p>
+          </div>
+
+          <ul className="search-summary-list">
+            {categorySummaries.map((summary) => (
+              <li className="search-summary" key={summary.category}>
+                <Link
+                  className="search-summary__title"
+                  to={`/categories/${encodeURIComponent(summary.category)}`}
+                >
+                  {summary.category}
+                </Link>
+                <p className="card__meta">
+                  {`${t('search.start.competitionCount', {
+                    count: summary.contestCount,
+                  })} · ${t('search.editorialCount', { count: summary.editorialCount })}`}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    )
+  } else if (contestResults.length === 0) {
+    resultsContent = <p className="muted">{t('search.empty')}</p>
+  } else {
+    resultsContent = (
+      <>
+        <p className="muted">{t('search.contestCount', { count: contestResults.length })}</p>
+
+        <ul className="card-list">
+          {contestResults.map((result) => (
+            <li className="card" key={`${result.category}::${result.contest}`}>
+              <div className="card__header">
+                <p className="card__meta">{result.category}</p>
+                <h2 className="card__title">{result.contest}</h2>
+                <p className="card__meta">
+                  {t('search.editorialCount', { count: result.editorials.length })}
+                </p>
+              </div>
+
+              <ul className="competition-editorials">
+                {result.editorials.map((editorial) => {
+                  const links = buildEditorialLinks(editorial.path)
+                  const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
+
+                  return (
+                    <li className="competition-editorials__item" key={editorial.id}>
+                      <div className="competition-editorials__main">
+                        <Link
+                          className="competition-editorials__title"
+                          to={`/editorials/${editorial.id}`}
+                        >
+                          {localizedTitle}
+                        </Link>
+                        <p className="card__meta">{editorial.path}</p>
+                      </div>
+                      <div className="action-links">
+                        <Link
+                          aria-label={t('editorial.viewAria', { title: localizedTitle })}
+                          className="action-link"
+                          rel="noreferrer"
+                          target="_blank"
+                          to={`/editorials/${editorial.id}/view`}
+                        >
+                          {t('editorial.view')}
+                        </Link>
+                        <a
+                          aria-label={t('editorial.downloadAria', { title: localizedTitle })}
+                          className="action-link action-link--secondary"
+                          href={links.downloadUrl}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          {t('editorial.download')}
+                        </a>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      </>
+    )
+  }
+
   return (
     <section className="page">
       <div className="page__header">
@@ -170,110 +280,7 @@ export function SearchPage() {
           />
         </div>
       </div>
-      {isEmptySearch ? (
-        <div className="search-start">
-          <div className="stats-grid">
-            <div className="stat-card">
-              <p className="stat-card__label">{t('search.start.categories')}</p>
-              <p className="stat-card__value">{categorySummaries.length}</p>
-            </div>
-            <div className="stat-card">
-              <p className="stat-card__label">{t('search.start.competitions')}</p>
-              <p className="stat-card__value">{allContestResults.length}</p>
-            </div>
-            <div className="stat-card">
-              <p className="stat-card__label">{t('search.start.editorials')}</p>
-              <p className="stat-card__value">{data.editorials.length}</p>
-            </div>
-          </div>
-
-          <div className="search-start__body">
-            <div>
-              <h2 className="search-start__heading">{t('search.start.heading')}</h2>
-              <p className="muted">{t('search.start.description')}</p>
-            </div>
-
-            <ul className="search-summary-list">
-              {categorySummaries.map((summary) => (
-                <li className="search-summary" key={summary.category}>
-                  <Link
-                    className="search-summary__title"
-                    to={`/categories/${encodeURIComponent(summary.category)}`}
-                  >
-                    {summary.category}
-                  </Link>
-                  <p className="card__meta">
-                    {`${t('search.start.competitionCount', {
-                      count: summary.contestCount,
-                    })} · ${t('search.editorialCount', { count: summary.editorialCount })}`}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      ) : contestResults.length === 0 ? (
-        <p className="muted">{t('search.empty')}</p>
-      ) : (
-        <>
-          <p className="muted">{t('search.contestCount', { count: contestResults.length })}</p>
-
-          <ul className="card-list">
-            {contestResults.map((result) => (
-              <li className="card" key={`${result.category}::${result.contest}`}>
-                <div className="card__header">
-                  <p className="card__meta">{result.category}</p>
-                  <h2 className="card__title">{result.contest}</h2>
-                  <p className="card__meta">
-                    {t('search.editorialCount', { count: result.editorials.length })}
-                  </p>
-                </div>
-
-                <ul className="competition-editorials">
-                  {result.editorials.map((editorial) => {
-                    const links = buildEditorialLinks(editorial.path)
-                    const localizedTitle = getLocalizedText(editorial.title, i18n.resolvedLanguage)
-
-                    return (
-                      <li className="competition-editorials__item" key={editorial.id}>
-                        <div className="competition-editorials__main">
-                          <Link
-                            className="competition-editorials__title"
-                            to={`/editorials/${editorial.id}`}
-                          >
-                            {localizedTitle}
-                          </Link>
-                          <p className="card__meta">{editorial.path}</p>
-                        </div>
-                        <div className="action-links">
-                          <Link
-                            aria-label={t('editorial.viewAria', { title: localizedTitle })}
-                            className="action-link"
-                            rel="noreferrer"
-                            target="_blank"
-                            to={`/editorials/${editorial.id}/view`}
-                          >
-                            {t('editorial.view')}
-                          </Link>
-                          <a
-                            aria-label={t('editorial.downloadAria', { title: localizedTitle })}
-                            className="action-link action-link--secondary"
-                            href={links.downloadUrl}
-                            rel="noreferrer"
-                            target="_blank"
-                          >
-                            {t('editorial.download')}
-                          </a>
-                        </div>
-                      </li>
-                    )
-                  })}
-                </ul>
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
+      {resultsContent}
     </section>
   )
 }

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -73,6 +73,16 @@ export const resources = {
         view: 'View',
         download: 'Download',
         empty: 'No competitions match your search.',
+        start: {
+          heading: 'Start with a keyword',
+          description:
+            'Search by competition, year, category, or editorial title to show the full matching editorial list.',
+          categories: 'Categories',
+          competitions: 'Competitions',
+          editorials: 'Editorials',
+          competitionCount_one: '{{count}} competition',
+          competitionCount_other: '{{count}} competitions',
+        },
       },
       categories: {
         heading: 'Browse by Category',
@@ -257,6 +267,16 @@ export const resources = {
         view: '열기',
         download: '다운로드',
         empty: '일치하는 대회가 없습니다.',
+        start: {
+          heading: '키워드로 검색을 시작하세요',
+          description:
+            '대회명, 연도, 카테고리, 해설 제목을 검색하면 일치하는 전체 해설 목록이 표시됩니다.',
+          categories: '카테고리',
+          competitions: '대회',
+          editorials: '해설',
+          competitionCount_one: '{{count}}개 대회',
+          competitionCount_other: '{{count}}개 대회',
+        },
       },
       categories: {
         heading: '카테고리별 보기',
@@ -438,6 +458,16 @@ export const resources = {
         view: '表示',
         download: 'ダウンロード',
         empty: '一致する大会がありません。',
+        start: {
+          heading: 'キーワードから検索を始める',
+          description:
+            '大会名、開催年、カテゴリ、エディトリアル名で検索すると、一致するエディトリアル一覧をすべて表示します。',
+          categories: 'カテゴリ',
+          competitions: '大会',
+          editorials: 'エディトリアル',
+          competitionCount_one: '{{count}} 件の大会',
+          competitionCount_other: '{{count}} 件の大会',
+        },
       },
       categories: {
         heading: 'カテゴリ別に見る',


### PR DESCRIPTION
## What

Add a lightweight empty-search state on `/search` that shows index totals and category summaries instead of expanding every competition and editorial before a query is entered.

Closes #109.

## Why

The previous empty-query behavior rendered all 49 competitions and 247 editorials immediately, which made the initial search page heavy and especially long on mobile. Search results remain complete once a user enters a query.

## Checklist

### Required

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [x] Search/filter/navigation behavior was verified for this change (if applicable)
- [x] Editorial index generation impact was verified (run `npm run index:generate` if applicable; not applicable, no index generation behavior changed)
- [x] I added or updated tests for changed behavior (if applicable; browser validation covered the UI behavior)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable; none introduced)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search page now shows a "search start" view for empty queries with category summaries and counts, plus the existing results view for non-empty queries
  * Added stats overview (categories, competitions, editorials) and a category browser with localized counts

* **Style**
  * New search layout and card styles, plus improved focus/hover behavior for search items

* **Documentation**
  * Updated routing docs to reflect revised search-route behavior

* **Localization**
  * Added translated copy for the search start view (en/ko/ja)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->