### PR TITLE
Reduce mobile header height and prioritize search navigation

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -183,6 +183,13 @@ a {
   flex-wrap: wrap;
 }
 
+.layout__nav-desktop {
+  display: flex;
+  gap: 0.45rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .layout__link {
   border-radius: 999px;
   color: var(--color-muted);
@@ -194,15 +201,62 @@ a {
   justify-content: center;
 }
 
+.layout__link--primary {
+  border: 1px solid var(--color-primary-strong);
+  background-color: var(--color-primary);
+  color: var(--color-on-primary);
+  box-shadow: var(--elevation-1);
+}
+
 .layout__brand:hover,
 .layout__link:hover {
   background-color: var(--color-surface-container);
   color: var(--color-primary-strong);
 }
 
+.layout__link--primary:hover {
+  background-color: var(--color-primary-strong);
+  color: var(--color-on-primary);
+  box-shadow: var(--elevation-2);
+}
+
 .layout__link--active {
   color: var(--color-primary-strong);
   background-color: var(--color-secondary-soft);
+}
+
+.layout__link--primary.layout__link--active {
+  color: var(--color-on-primary);
+  background-color: var(--color-primary-strong);
+}
+
+.layout__menu-button {
+  border: 1px solid var(--color-border-strong);
+  border-radius: 999px;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.75rem;
+  font: inherit;
+  font-weight: 700;
+  color: var(--color-primary-strong);
+  background-color: var(--color-surface-container-low);
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.layout__menu-button:hover,
+.layout__menu-button[aria-expanded='true'] {
+  background-color: var(--color-surface-container-high);
+}
+
+.layout__menu-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.layout__mobile-menu {
+  display: none;
 }
 
 .layout__content {
@@ -851,6 +905,7 @@ a {
 
 .layout__link:focus-visible,
 .layout__brand:focus-visible,
+.layout__menu-button:focus-visible,
 .layout__footer-link:focus-visible,
 .layout__footer-external:focus-visible,
 .card__title:focus-visible,
@@ -876,18 +931,91 @@ a {
   }
 
   .layout__header-inner {
-    align-items: stretch;
-    flex-direction: column;
-    gap: 0.7rem;
+    align-items: center;
+    flex-direction: row;
+    gap: 0.45rem;
+    padding: 0.45rem 0.75rem;
+    position: relative;
+  }
+
+  .layout__brand {
+    min-width: 0;
+    min-height: 2.25rem;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.95rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .layout__nav {
-    align-items: stretch;
+    align-items: center;
     gap: 0.35rem;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    margin-left: auto;
+    position: relative;
+  }
+
+  .layout__nav-desktop {
+    display: none;
   }
 
   .layout__link {
-    flex: 1 1 auto;
+    min-height: 2.25rem;
+    padding: 0.4rem 0.7rem;
+  }
+
+  .layout__menu-button {
+    display: inline-flex;
+  }
+
+  .layout__mobile-menu {
+    position: absolute;
+    top: calc(100% + 0.55rem);
+    right: 0;
+    width: min(18rem, calc(100vw - 1.5rem));
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: var(--color-surface);
+    box-shadow: var(--elevation-3);
+    padding: 0.65rem;
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .layout__mobile-menu[hidden] {
+    display: none;
+  }
+
+  .layout__mobile-links {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .layout__mobile-links .layout__link {
+    border-radius: 0.5rem;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .layout__mobile-preferences {
+    border-top: 1px solid var(--color-border);
+    padding-top: 0.65rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.65rem;
+  }
+
+  .layout__mobile-preferences .muted {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .layout__mobile-preferences .language-selector {
+    max-width: 8.5rem;
   }
 
   .home-dashboard {

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -11,6 +11,7 @@ export const resources = {
         categories: 'Categories',
         contribute: 'Upload Guide',
         copyright: 'Copyright',
+        menu: 'Menu',
       },
       footer: {
         description: 'A curated archive for competitive-programming contest editorials.',
@@ -206,6 +207,7 @@ export const resources = {
         categories: '카테고리',
         contribute: '업로드 가이드',
         copyright: '저작권',
+        menu: '메뉴',
       },
       footer: {
         description: '경쟁 프로그래밍 대회 에디토리얼을 모아 둔 아카이브입니다.',
@@ -396,6 +398,7 @@ export const resources = {
         categories: 'カテゴリ',
         contribute: 'アップロードガイド',
         copyright: '著作権',
+        menu: 'メニュー',
       },
       footer: {
         description: '競技プログラミング大会のエディトリアルを集約したアーカイブです。',

--- a/src/shared/ui/LanguageSelector.tsx
+++ b/src/shared/ui/LanguageSelector.tsx
@@ -1,5 +1,9 @@
 import { useTranslation } from 'react-i18next'
 
+interface LanguageSelectorProps {
+  readonly id?: string
+}
+
 const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'ko', label: '한국어' },
@@ -16,7 +20,7 @@ function normalizeLanguage(language: string | undefined) {
   return language.toLowerCase().split(/[-_]/)[0] ?? DEFAULT_LANGUAGE
 }
 
-export function LanguageSelector() {
+export function LanguageSelector({ id = 'language-selector' }: LanguageSelectorProps) {
   const { t, i18n } = useTranslation()
   const normalizedLanguage = normalizeLanguage(i18n.resolvedLanguage ?? i18n.language)
   const currentLanguage = SUPPORTED_LANGUAGE_CODES.has(normalizedLanguage)
@@ -24,11 +28,11 @@ export function LanguageSelector() {
     : DEFAULT_LANGUAGE
 
   return (
-    <label className="muted" htmlFor="language-selector">
+    <label className="muted" htmlFor={id}>
       {t('language.label')}{' '}
       <select
         className="language-selector"
-        id="language-selector"
+        id={id}
         onChange={(event) => {
           void i18n.changeLanguage(event.target.value)
         }}

--- a/src/shared/ui/Layout.tsx
+++ b/src/shared/ui/Layout.tsx
@@ -32,19 +32,19 @@ export function Layout() {
   const year = new Date().getFullYear()
   const mobileMenuId = 'mobile-navigation-menu'
 
-  function renderSecondaryLinks() {
+  function renderSecondaryLinks(onNavigate?: () => void) {
     return (
       <>
-        <NavLink className={navLinkClassName} to="/" end>
+        <NavLink className={navLinkClassName} onClick={onNavigate} to="/" end>
           {t('nav.home')}
         </NavLink>
-        <NavLink className={navLinkClassName} to="/categories">
+        <NavLink className={navLinkClassName} onClick={onNavigate} to="/categories">
           {t('nav.categories')}
         </NavLink>
-        <NavLink className={navLinkClassName} to="/contribute">
+        <NavLink className={navLinkClassName} onClick={onNavigate} to="/contribute">
           {t('nav.contribute')}
         </NavLink>
-        <NavLink className={navLinkClassName} to="/copyright">
+        <NavLink className={navLinkClassName} onClick={onNavigate} to="/copyright">
           {t('nav.copyright')}
         </NavLink>
       </>
@@ -85,8 +85,8 @@ export function Layout() {
               <span>{t('nav.menu')}</span>
             </button>
             <div className="layout__mobile-menu" hidden={!isMobileMenuOpen} id={mobileMenuId}>
-              <div className="layout__mobile-links" onClick={() => setIsMobileMenuOpen(false)}>
-                {renderSecondaryLinks()}
+              <div className="layout__mobile-links">
+                {renderSecondaryLinks(() => setIsMobileMenuOpen(false))}
               </div>
               <div className="layout__mobile-preferences">
                 <ThemeSelector onThemeChange={setTheme} theme={theme} />

--- a/src/shared/ui/Layout.tsx
+++ b/src/shared/ui/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, NavLink, Outlet } from 'react-router-dom'
 import { useThemePreference } from '../hooks/useThemePreference'
@@ -8,10 +9,47 @@ function navLinkClassName({ isActive }: { isActive: boolean }) {
   return `layout__link${isActive ? ' layout__link--active' : ''}`
 }
 
+function MenuIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="layout__menu-icon"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M4 7h16M4 12h16M4 17h16" />
+    </svg>
+  )
+}
+
 export function Layout() {
   const { t } = useTranslation()
   const { theme, setTheme } = useThemePreference()
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const year = new Date().getFullYear()
+  const mobileMenuId = 'mobile-navigation-menu'
+
+  function renderSecondaryLinks() {
+    return (
+      <>
+        <NavLink className={navLinkClassName} to="/" end>
+          {t('nav.home')}
+        </NavLink>
+        <NavLink className={navLinkClassName} to="/categories">
+          {t('nav.categories')}
+        </NavLink>
+        <NavLink className={navLinkClassName} to="/contribute">
+          {t('nav.contribute')}
+        </NavLink>
+        <NavLink className={navLinkClassName} to="/copyright">
+          {t('nav.copyright')}
+        </NavLink>
+      </>
+    )
+  }
 
   return (
     <div className="layout">
@@ -21,23 +59,40 @@ export function Layout() {
             {t('appTitle')}
           </Link>
           <nav className="layout__nav">
-            <NavLink className={navLinkClassName} to="/" end>
-              {t('nav.home')}
-            </NavLink>
-            <NavLink className={navLinkClassName} to="/search">
+            <NavLink
+              className={({ isActive }) =>
+                `${navLinkClassName({ isActive })} layout__link--primary`
+              }
+              onClick={() => setIsMobileMenuOpen(false)}
+              to="/search"
+            >
               {t('nav.search')}
             </NavLink>
-            <NavLink className={navLinkClassName} to="/categories">
-              {t('nav.categories')}
-            </NavLink>
-            <NavLink className={navLinkClassName} to="/contribute">
-              {t('nav.contribute')}
-            </NavLink>
-            <NavLink className={navLinkClassName} to="/copyright">
-              {t('nav.copyright')}
-            </NavLink>
-            <ThemeSelector onThemeChange={setTheme} theme={theme} />
-            <LanguageSelector />
+            <div className="layout__nav-desktop">
+              {renderSecondaryLinks()}
+              <ThemeSelector onThemeChange={setTheme} theme={theme} />
+              <LanguageSelector />
+            </div>
+            <button
+              aria-controls={mobileMenuId}
+              aria-expanded={isMobileMenuOpen}
+              aria-label={t('nav.menu')}
+              className="layout__menu-button"
+              onClick={() => setIsMobileMenuOpen((isOpen) => !isOpen)}
+              type="button"
+            >
+              <MenuIcon />
+              <span>{t('nav.menu')}</span>
+            </button>
+            <div className="layout__mobile-menu" hidden={!isMobileMenuOpen} id={mobileMenuId}>
+              <div className="layout__mobile-links" onClick={() => setIsMobileMenuOpen(false)}>
+                {renderSecondaryLinks()}
+              </div>
+              <div className="layout__mobile-preferences">
+                <ThemeSelector onThemeChange={setTheme} theme={theme} />
+                <LanguageSelector id="mobile-language-selector" />
+              </div>
+            </div>
           </nav>
         </div>
       </header>


### PR DESCRIPTION
## What

Reduce the mobile header to a compact brand, search, and menu layout. Keep search visible as the primary header action, and move secondary navigation, theme, and language controls into an accessible mobile menu.

Closes #110.

## Why

The previous mobile header could wrap into a taller layout, pushing the primary search path lower on small screens. This keeps search easy to reach while preserving access to navigation and preferences.

## Checklist

### Required

- [ ] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [ ] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsible mobile navigation with an accessible menu button and keyboard focus styling
  * Responsive navigation that adapts layout between desktop and mobile
  * Added a dedicated search link in the primary navigation
  * Menu label translations added for English, Korean, and Japanese

* **Style**
  * Updated header and navigation styling for improved spacing, link appearance, and mobile dropdown behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->