### PR TITLE
Strengthen the top-level category browsing experience

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -558,6 +558,65 @@ a {
   overflow-wrap: anywhere;
 }
 
+.category-card {
+  gap: 0.75rem;
+}
+
+.category-card__top {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.category-card__count {
+  flex: 0 0 auto;
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background-color: var(--color-surface-container-low);
+  color: var(--color-primary-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.28rem 0.65rem;
+  white-space: nowrap;
+}
+
+.category-card__section {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.category-card__label {
+  margin: 0;
+  color: var(--color-muted-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.category-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.category-card__chip {
+  max-width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background-color: var(--color-surface-container-low);
+  color: var(--color-muted);
+  font-size: 0.84rem;
+  line-height: 1.45;
+  padding: 0.35rem 0.55rem;
+  overflow-wrap: anywhere;
+}
+
 .home-page {
   gap: 1.5rem;
 }
@@ -1177,6 +1236,14 @@ a {
 
   .competition-editorials__item {
     display: grid;
+  }
+
+  .category-card__top {
+    display: grid;
+  }
+
+  .category-card__count {
+    width: fit-content;
   }
 
   .layout__footer-inner {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -569,6 +569,14 @@ a {
   align-items: flex-start;
 }
 
+.category-card__top .card__title {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .category-card__count {
   flex: 0 0 auto;
   margin: 0;

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -21,7 +21,10 @@ function addUniqueValue(values: string[], value: string, limit: number): void {
   values.push(value)
 }
 
-function summarizeCategories(editorials: EditorialRecord[]): CategorySummary[] {
+function summarizeCategories(
+  editorials: EditorialRecord[],
+  uncategorizedLabel: string,
+): CategorySummary[] {
   const summaries = new Map<
     string,
     {
@@ -33,7 +36,7 @@ function summarizeCategories(editorials: EditorialRecord[]): CategorySummary[] {
   >()
 
   editorials.forEach((editorial) => {
-    const category = editorial.categories[0] ?? 'Uncategorized'
+    const category = editorial.categories[0] ?? uncategorizedLabel
     const currentSummary = summaries.get(category) ?? {
       editorialCount: 0,
       childPaths: new Set<string>(),
@@ -67,7 +70,11 @@ function summarizeCategories(editorials: EditorialRecord[]): CategorySummary[] {
 export function CategoriesPage() {
   const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
-  const categories = useMemo(() => summarizeCategories(data.editorials), [data.editorials])
+  const uncategorizedLabel = t('categories.uncategorized')
+  const categories = useMemo(
+    () => summarizeCategories(data.editorials, uncategorizedLabel),
+    [data.editorials, uncategorizedLabel],
+  )
 
   usePageMetadata({
     title: `${t('categories.heading')} | ${t('appTitle')}`,

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -4,15 +4,63 @@ import type { EditorialRecord } from '../entities/editorial/model/types'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 
-function categoriesWithCount(editorials: EditorialRecord[]) {
-  const countMap = new Map<string, number>()
+interface CategorySummary {
+  category: string
+  editorialCount: number
+  childPathCount: number
+  childPathExamples: string[]
+  contestExamples: string[]
+}
+
+function addUniqueValue(values: string[], value: string, limit: number): void {
+  if (values.includes(value) || values.length >= limit) {
+    return
+  }
+
+  values.push(value)
+}
+
+function summarizeCategories(editorials: EditorialRecord[]): CategorySummary[] {
+  const summaries = new Map<
+    string,
+    {
+      editorialCount: number
+      childPaths: Set<string>
+      childPathExamples: string[]
+      contestExamples: string[]
+    }
+  >()
 
   editorials.forEach((editorial) => {
     const category = editorial.categories[0] ?? 'Uncategorized'
-    countMap.set(category, (countMap.get(category) ?? 0) + 1)
+    const currentSummary = summaries.get(category) ?? {
+      editorialCount: 0,
+      childPaths: new Set<string>(),
+      childPathExamples: [],
+      contestExamples: [],
+    }
+
+    currentSummary.editorialCount += 1
+
+    if (editorial.categories.length > 1) {
+      const childPath = editorial.categories.slice(0, 3).join(' > ')
+      currentSummary.childPaths.add(childPath)
+      addUniqueValue(currentSummary.childPathExamples, childPath, 3)
+    }
+
+    addUniqueValue(currentSummary.contestExamples, editorial.contest, 3)
+    summaries.set(category, currentSummary)
   })
 
-  return Array.from(countMap.entries()).sort((left, right) => left[0].localeCompare(right[0]))
+  return Array.from(summaries.entries())
+    .map(([category, summary]) => ({
+      category,
+      editorialCount: summary.editorialCount,
+      childPathCount: summary.childPaths.size,
+      childPathExamples: summary.childPathExamples,
+      contestExamples: summary.contestExamples,
+    }))
+    .sort((left, right) => left.category.localeCompare(right.category))
 }
 
 export function CategoriesPage() {
@@ -33,21 +81,72 @@ export function CategoriesPage() {
     return <p className="error">{error.message}</p>
   }
 
-  const categories = categoriesWithCount(data.editorials)
+  const categories = summarizeCategories(data.editorials)
 
   return (
     <section className="page">
-      <h1>{t('categories.heading')}</h1>
+      <div className="page__header">
+        <h1>{t('categories.heading')}</h1>
+        <p className="page__description">{t('categories.description')}</p>
+      </div>
       {categories.length === 0 ? (
         <p className="muted">{t('categories.empty')}</p>
       ) : (
         <ul className="card-list">
-          {categories.map(([category, count]) => (
-            <li className="card" key={category}>
-              <Link className="card__title" to={`/categories/${encodeURIComponent(category)}`}>
-                {category}
-              </Link>
-              <p className="card__meta">{t('categories.count', { count })}</p>
+          {categories.map((summary) => (
+            <li className="card category-card" key={summary.category}>
+              <div className="category-card__top">
+                <Link
+                  className="card__title"
+                  to={`/categories/${encodeURIComponent(summary.category)}`}
+                >
+                  {summary.category}
+                </Link>
+                <p className="category-card__count">
+                  {t('categories.count', { count: summary.editorialCount })}
+                </p>
+              </div>
+
+              <p className="card__meta">
+                {summary.childPathCount > 0
+                  ? t('categories.summary.withPaths', { count: summary.childPathCount })
+                  : t('categories.summary.direct')}
+              </p>
+
+              {summary.childPathExamples.length > 0 && (
+                <div className="category-card__section">
+                  <p className="category-card__label">{t('categories.pathExamples')}</p>
+                  <ul className="category-card__chips">
+                    {summary.childPathExamples.map((path) => (
+                      <li className="category-card__chip" key={path}>
+                        {path}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {summary.contestExamples.length > 0 && (
+                <div className="category-card__section">
+                  <p className="category-card__label">{t('categories.contestExamples')}</p>
+                  <p className="card__meta">{summary.contestExamples.join(' · ')}</p>
+                </div>
+              )}
+
+              <div className="action-links">
+                <Link
+                  className="action-link"
+                  to={`/categories/${encodeURIComponent(summary.category)}`}
+                >
+                  {t('categories.browse')}
+                </Link>
+                <Link
+                  className="action-link action-link--secondary"
+                  to={`/search?category=${encodeURIComponent(summary.category)}`}
+                >
+                  {t('categories.search')}
+                </Link>
+              </div>
             </li>
           ))}
         </ul>

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { EditorialRecord } from '../entities/editorial/model/types'
@@ -66,6 +67,7 @@ function summarizeCategories(editorials: EditorialRecord[]): CategorySummary[] {
 export function CategoriesPage() {
   const { t, i18n } = useTranslation()
   const { data, isLoading, error } = useEditorialIndex()
+  const categories = useMemo(() => summarizeCategories(data.editorials), [data.editorials])
 
   usePageMetadata({
     title: `${t('categories.heading')} | ${t('appTitle')}`,
@@ -80,8 +82,6 @@ export function CategoriesPage() {
   if (error) {
     return <p className="error">{error.message}</p>
   }
-
-  const categories = summarizeCategories(data.editorials)
 
   return (
     <section className="page">

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -13,6 +13,9 @@ interface CategorySummary {
   contestExamples: string[]
 }
 
+/**
+ * Adds a representative example while keeping examples unique and capped.
+ */
 function addUniqueValue(values: string[], value: string, limit: number): void {
   if (values.includes(value) || values.length >= limit) {
     return
@@ -21,6 +24,9 @@ function addUniqueValue(values: string[], value: string, limit: number): void {
   values.push(value)
 }
 
+/**
+ * Groups editorials into top-level category cards with compact browsing context.
+ */
 function summarizeCategories(
   editorials: EditorialRecord[],
   uncategorizedLabel: string,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -257,8 +257,13 @@ export function SearchPage() {
   const { data, isLoading, error } = useEditorialIndex()
   const [searchParams] = useSearchParams()
   const urlQuery = searchParams.get('q') ?? ''
+  const urlCategoryParam = searchParams.get('category')?.trim()
+  const urlCategory =
+    urlCategoryParam !== undefined && urlCategoryParam.length > 0
+      ? urlCategoryParam
+      : ALL_FILTER_VALUE
   const [query, setQuery] = useState(urlQuery)
-  const [selectedCategory, setSelectedCategory] = useState(ALL_FILTER_VALUE)
+  const [selectedCategory, setSelectedCategory] = useState(urlCategory)
   const [selectedYear, setSelectedYear] = useState(ALL_FILTER_VALUE)
   const normalizedQuery = query.trim()
   const hasActiveFilters =
@@ -313,6 +318,10 @@ export function SearchPage() {
   useEffect(() => {
     setQuery(urlQuery)
   }, [urlQuery])
+
+  useEffect(() => {
+    setSelectedCategory(urlCategory)
+  }, [urlCategory])
 
   if (isLoading) {
     return <p className="muted">{t('common.loading')}</p>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -152,7 +152,7 @@ function summarizeByCategory(contestResults: ContestResult[]): CategorySummary[]
 }
 
 /**
- * Returns matching contest groups while leaving empty-query display to the summary state.
+ * Extracts the first contest year visible in editorial metadata.
  */
 function getEditorialYear(editorial: EditorialRecord): string | null {
   const searchableText = [
@@ -167,24 +167,39 @@ function getEditorialYear(editorial: EditorialRecord): string | null {
   return match?.[0] ?? null
 }
 
+/**
+ * Builds the visible category breadcrumb for an editorial result.
+ */
 function getCategoryBreadcrumb(editorial: EditorialRecord, fallback: string): string {
   return editorial.categories.length > 0 ? editorial.categories.join(' > ') : fallback
 }
 
+/**
+ * Checks whether an editorial belongs to the active category filter.
+ */
 function isEditorialInCategory(editorial: EditorialRecord, category: string): boolean {
   return category === ALL_FILTER_VALUE || editorial.categories.includes(category)
 }
 
+/**
+ * Falls back to the unfiltered state when a URL category is stale or unknown.
+ */
 function normalizeCategoryFilter(category: string, categoryOptions: string[]): string {
   return category === ALL_FILTER_VALUE || categoryOptions.includes(category)
     ? category
     : ALL_FILTER_VALUE
 }
 
+/**
+ * Checks whether an editorial belongs to the active year filter.
+ */
 function isEditorialInYear(editorial: EditorialRecord, year: string): boolean {
   return year === ALL_FILTER_VALUE || getEditorialYear(editorial) === year
 }
 
+/**
+ * Returns matching contest groups while leaving empty-query display to the summary state.
+ */
 function filterContestResults(
   contestResults: ContestResult[],
   query: string,
@@ -216,6 +231,9 @@ function filterContestResults(
     .filter((result) => result.editorials.length > 0)
 }
 
+/**
+ * Highlights the first query match inside a bounded result snippet.
+ */
 function buildHighlightedSnippet(value: string, query: string, maxLength = 96): ReactNode {
   const normalizedQuery = query.trim()
   if (normalizedQuery.length === 0) {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -175,6 +175,12 @@ function isEditorialInCategory(editorial: EditorialRecord, category: string): bo
   return category === ALL_FILTER_VALUE || editorial.categories.includes(category)
 }
 
+function normalizeCategoryFilter(category: string, categoryOptions: string[]): string {
+  return category === ALL_FILTER_VALUE || categoryOptions.includes(category)
+    ? category
+    : ALL_FILTER_VALUE
+}
+
 function isEditorialInYear(editorial: EditorialRecord, year: string): boolean {
   return year === ALL_FILTER_VALUE || getEditorialYear(editorial) === year
 }
@@ -258,10 +264,20 @@ export function SearchPage() {
   const [searchParams] = useSearchParams()
   const urlQuery = searchParams.get('q') ?? ''
   const urlCategoryParam = searchParams.get('category')?.trim()
-  const urlCategory =
+  const requestedUrlCategory =
     urlCategoryParam !== undefined && urlCategoryParam.length > 0
       ? urlCategoryParam
       : ALL_FILTER_VALUE
+
+  const categoryOptions = useMemo(
+    () =>
+      Array.from(new Set(data.editorials.flatMap((editorial) => editorial.categories))).sort(
+        (left, right) => left.localeCompare(right),
+      ),
+    [data.editorials],
+  )
+
+  const urlCategory = normalizeCategoryFilter(requestedUrlCategory, categoryOptions)
   const [query, setQuery] = useState(urlQuery)
   const [selectedCategory, setSelectedCategory] = useState(urlCategory)
   const [selectedYear, setSelectedYear] = useState(ALL_FILTER_VALUE)
@@ -293,14 +309,6 @@ export function SearchPage() {
   const categorySummaries = useMemo(
     () => summarizeByCategory(allContestResults),
     [allContestResults],
-  )
-
-  const categoryOptions = useMemo(
-    () =>
-      Array.from(new Set(data.editorials.flatMap((editorial) => editorial.categories))).sort(
-        (left, right) => left.localeCompare(right),
-      ),
-    [data.editorials],
   )
 
   const yearOptions = useMemo(

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -109,9 +109,20 @@ export const resources = {
       },
       categories: {
         heading: 'Browse by Category',
+        description:
+          'Top-level categories collect related contest families. Use the path and contest examples to choose where to continue browsing.',
         empty: 'No categories are available yet.',
         count_one: '{{count}} editorial',
         count_other: '{{count}} editorials',
+        summary: {
+          withPaths_one: 'Includes {{count}} representative child path.',
+          withPaths_other: 'Includes {{count}} representative child paths.',
+          direct: 'Lists contests directly under this category.',
+        },
+        pathExamples: 'Path examples',
+        contestExamples: 'Contest examples',
+        browse: 'Browse',
+        search: 'Search this category',
       },
       category: {
         heading: 'Category: {{category}}',
@@ -326,9 +337,20 @@ export const resources = {
       },
       categories: {
         heading: '카테고리별 보기',
+        description:
+          '최상위 카테고리는 관련 대회 계열을 묶습니다. 경로와 대회 예시를 보고 다음 탐색 위치를 고르세요.',
         empty: '등록된 카테고리가 없습니다.',
         count_one: '{{count}}개 에디토리얼',
         count_other: '{{count}}개 에디토리얼',
+        summary: {
+          withPaths_one: '대표 하위 경로 {{count}}개를 포함합니다.',
+          withPaths_other: '대표 하위 경로 {{count}}개를 포함합니다.',
+          direct: '이 카테고리 바로 아래의 대회를 보여줍니다.',
+        },
+        pathExamples: '경로 예시',
+        contestExamples: '대회 예시',
+        browse: '탐색',
+        search: '이 카테고리 검색',
       },
       category: {
         heading: '카테고리: {{category}}',
@@ -540,9 +562,20 @@ export const resources = {
       },
       categories: {
         heading: 'カテゴリ別に見る',
+        description:
+          'トップレベルカテゴリは関連する大会群をまとめます。パスと大会例を見ながら、次に進む場所を選べます。',
         empty: 'カテゴリはまだありません。',
         count_one: '{{count}} 件のエディトリアル',
         count_other: '{{count}} 件のエディトリアル',
+        summary: {
+          withPaths_one: '{{count}} 件の代表的な子パスがあります。',
+          withPaths_other: '{{count}} 件の代表的な子パスがあります。',
+          direct: 'このカテゴリ直下の大会を表示します。',
+        },
+        pathExamples: 'パス例',
+        contestExamples: '大会例',
+        browse: '閲覧',
+        search: 'このカテゴリを検索',
       },
       category: {
         heading: 'カテゴリ: {{category}}',

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -111,6 +111,7 @@ export const resources = {
         heading: 'Browse by Category',
         description:
           'Top-level categories collect related contest families. Use the path and contest examples to choose where to continue browsing.',
+        uncategorized: 'Uncategorized',
         empty: 'No categories are available yet.',
         count_one: '{{count}} editorial',
         count_other: '{{count}} editorials',
@@ -339,6 +340,7 @@ export const resources = {
         heading: '카테고리별 보기',
         description:
           '최상위 카테고리는 관련 대회 계열을 묶습니다. 경로와 대회 예시를 보고 다음 탐색 위치를 고르세요.',
+        uncategorized: '미분류',
         empty: '등록된 카테고리가 없습니다.',
         count_one: '{{count}}개 에디토리얼',
         count_other: '{{count}}개 에디토리얼',
@@ -564,6 +566,7 @@ export const resources = {
         heading: 'カテゴリ別に見る',
         description:
           'トップレベルカテゴリは関連する大会群をまとめます。パスと大会例を見ながら、次に進む場所を選べます。',
+        uncategorized: '未分類',
         empty: 'カテゴリはまだありません。',
         count_one: '{{count}} 件のエディトリアル',
         count_other: '{{count}} 件のエディトリアル',


### PR DESCRIPTION
## What

Strengthened the `/categories` browsing experience with contextual category cards, representative child paths, contest examples, and a category-specific search entry point.

Closes #112.

## Why

New users previously saw only top-level category names and editorial counts, which made the hierarchy harder to understand before drilling in. The updated cards make the category structure more legible while keeping the page compact and scannable.

## Checklist

### Required

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [x] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category cards show editorial counts, example child-path chips, and contest examples; entries labeled “with paths” or “direct”.
  * Search page preserves and syncs the selected category from the URL query parameter.

* **Style**
  * Improved category-card styles: spaced layout, truncated titles with count pill, wrapping/breaking chips, and responsive narrow-viewport layout.

* **Localization**
  * Expanded category-related translations for English, Korean, and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->