### PR TITLE
Use semantic breadcrumb markup on category pages

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -376,6 +376,33 @@ a {
   max-width: 760px;
 }
 
+.breadcrumb {
+  color: var(--color-muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  max-width: 760px;
+}
+
+.breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.breadcrumb__item + .breadcrumb__item::before {
+  content: '>';
+  color: var(--color-muted-soft);
+}
+
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -125,23 +125,30 @@ export function CategoryPage() {
   return (
     <section className="page">
       <h1>{heading}</h1>
-      <p className="page__description">
-        <Link to="/categories">{t('categories.heading')}</Link>
-        {selectedSegments.map((segment, index) => {
-          const isCurrent = index === selectedSegments.length - 1
-          const route = `/categories/${selectedSegments
-            .slice(0, index + 1)
-            .map(encodeURIComponent)
-            .join('/')}`
+      <nav aria-label={t('category.breadcrumb')} className="breadcrumb">
+        <ol className="breadcrumb__list">
+          <li className="breadcrumb__item">
+            <Link to="/categories">{t('categories.heading')}</Link>
+          </li>
+          {selectedSegments.map((segment, index) => {
+            const isCurrent = index === selectedSegments.length - 1
+            const route = `/categories/${selectedSegments
+              .slice(0, index + 1)
+              .map(encodeURIComponent)
+              .join('/')}`
 
-          return (
-            <span key={`${segment}-${index}`}>
-              {' > '}
-              {isCurrent ? segment : <Link to={route}>{segment}</Link>}
-            </span>
-          )
-        })}
-      </p>
+            return (
+              <li className="breadcrumb__item" key={`${segment}-${index}`}>
+                {isCurrent ? (
+                  <span aria-current="page">{segment}</span>
+                ) : (
+                  <Link to={route}>{segment}</Link>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      </nav>
 
       {childNodes.length > 0 && (
         <ul className="card-list">

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -126,6 +126,7 @@ export const resources = {
         search: 'Search this category',
       },
       category: {
+        breadcrumb: 'Category breadcrumb',
         heading: 'Category: {{category}}',
         unknown: 'Unknown',
         empty: 'No contests are available in this category.',
@@ -361,6 +362,7 @@ export const resources = {
         search: '이 카테고리 검색',
       },
       category: {
+        breadcrumb: '카테고리 이동 경로',
         heading: '카테고리: {{category}}',
         unknown: '알 수 없음',
         empty: '해당 카테고리에 대회가 없습니다.',
@@ -593,6 +595,7 @@ export const resources = {
         search: 'このカテゴリを検索',
       },
       category: {
+        breadcrumb: 'カテゴリのパンくずリスト',
         heading: 'カテゴリ: {{category}}',
         unknown: '不明',
         empty: 'このカテゴリに大会はありません。',


### PR DESCRIPTION
## What

Use semantic breadcrumb markup on category pages while preserving the existing visual breadcrumb trail.

Closes #114.

## Why

Category breadcrumbs should be exposed as breadcrumb navigation to assistive technologies and clearly identify the current hierarchy position.

## Checklist

### Required

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [x] Search/filter/navigation behavior was verified for this change (if applicable)
- [x] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to category pages, helping users understand their location within the site hierarchy. Now available in English, Korean, and Japanese.

* **Style**
  * Implemented breadcrumb styling with visual separators for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->