### PR TITLE
Add stronger fallback and navigation actions to the PDF viewer page

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1027,6 +1027,15 @@ a {
   box-shadow: var(--elevation-2);
 }
 
+.viewer-fallback {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.viewer-fallback .error {
+  margin: 0;
+}
+
 .tag-list {
   display: flex;
   gap: 0.4rem;

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
+import { buildCategoryRoute, getDirectorySegments } from '../shared/api/categoryRoutes'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { usePageMetadata } from '../shared/hooks/usePageMetadata'
@@ -26,15 +27,6 @@ function decodeHierarchyPath(value: string | undefined): string[] {
     .map(decodePathSegment)
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0)
-}
-
-function getDirectorySegments(path: string): string[] {
-  const segments = path
-    .split('/')
-    .map((segment) => segment.trim())
-    .filter((segment) => segment.length > 0)
-
-  return segments.slice(0, -1)
 }
 
 function isMatchingPrefix(segments: string[], prefix: string[]): boolean {
@@ -80,7 +72,7 @@ export function CategoryPage() {
         .map(([name, count]) => ({
           name,
           count,
-          route: `/categories/${[...selectedSegments, name].map(encodeURIComponent).join('/')}`,
+          route: buildCategoryRoute([...selectedSegments, name]),
         }))
         .sort((left, right) => left.name.localeCompare(right.name)),
       editorialsAtNode: sortedEditorialsAtNode,

--- a/src/pages/EditorialDetailPage.tsx
+++ b/src/pages/EditorialDetailPage.tsx
@@ -2,23 +2,11 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
 import type { EditorialRecord } from '../entities/editorial/model/types'
+import { buildCategoryRoute, getDirectorySegments } from '../shared/api/categoryRoutes'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { buildEditorialPreviewImagePath, usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
-
-function getDirectorySegments(path: string): string[] {
-  const segments = path
-    .split('/')
-    .map((segment) => segment.trim())
-    .filter((segment) => segment.length > 0)
-
-  return segments.slice(0, -1)
-}
-
-function buildCategoryRoute(segments: string[]): string {
-  return `/categories/${segments.map(encodeURIComponent).join('/')}`
-}
 
 function getRelatedEditorials(
   editorials: EditorialRecord[],

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -1,10 +1,23 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
+
+function getDirectorySegments(path: string): string[] {
+  const segments = path
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+
+  return segments.slice(0, -1)
+}
+
+function buildCategoryRoute(segments: string[]): string {
+  return `/categories/${segments.map(encodeURIComponent).join('/')}`
+}
 
 export function EditorialViewerPage() {
   const { t, i18n } = useTranslation()
@@ -118,13 +131,40 @@ export function EditorialViewerPage() {
   }
 
   const links = buildEditorialLinks(editorial.path)
+  const detailRoute = `/editorials/${editorial.id}`
+  const directorySegments = getDirectorySegments(editorial.path)
+  const contestRoute = buildCategoryRoute(directorySegments)
+  const categoryLinks = editorial.categories.map((category, index) => ({
+    label: category,
+    route: buildCategoryRoute(editorial.categories.slice(0, index + 1)),
+  }))
+  const categoryLabel = editorial.categories.length > 0 ? editorial.categories.join(' > ') : '-'
 
   return (
     <article className="page">
       <h1>{localizedTitle}</h1>
       <p className="page__description">{t('editorial.viewerDescription')}</p>
-      <p className="muted">{`${t('editorial.path')}: ${editorial.path}`}</p>
+
+      <div className="stats-grid">
+        <div className="stat-card">
+          <p className="stat-card__label">{t('editorial.contest')}</p>
+          <Link className="stat-card__value stat-card__link" to={contestRoute}>
+            {editorial.contest}
+          </Link>
+        </div>
+        <div className="stat-card">
+          <p className="stat-card__label">{t('editorial.category')}</p>
+          <p className="stat-card__value">{categoryLabel}</p>
+        </div>
+      </div>
+
       <div className="action-links">
+        <Link className="action-link" to={detailRoute}>
+          {t('editorial.backToDetail')}
+        </Link>
+        <Link className="action-link action-link--secondary" to={contestRoute}>
+          {t('editorial.browseContest')}
+        </Link>
         <a
           aria-label={t('editorial.downloadAria', { title: localizedTitle })}
           className="action-link action-link--secondary"
@@ -136,7 +176,36 @@ export function EditorialViewerPage() {
         </a>
       </div>
 
-      {pdfError && <p className="error">{t('editorial.viewerLoadFailed')}</p>}
+      {categoryLinks.length > 0 && (
+        <nav aria-label={t('editorial.categoryNavigation')} className="tag-list">
+          {categoryLinks.map((category) => (
+            <Link className="tag tag--link" key={category.route} to={category.route}>
+              {category.label}
+            </Link>
+          ))}
+        </nav>
+      )}
+
+      {pdfError && (
+        <section aria-label={t('editorial.viewerFailureActions')} className="viewer-fallback">
+          <p className="error">{t('editorial.viewerLoadFailed')}</p>
+          <p className="muted">{t('editorial.viewerFailureDescription')}</p>
+          <div className="action-links">
+            <a
+              aria-label={t('editorial.downloadAria', { title: localizedTitle })}
+              className="action-link"
+              href={links.downloadUrl}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t('editorial.download')}
+            </a>
+            <Link className="action-link action-link--secondary" to={detailRoute}>
+              {t('editorial.backToDetail')}
+            </Link>
+          </div>
+        </section>
+      )}
       {!pdfError && !pdfUrl && <p className="muted">{t('editorial.viewerLoading')}</p>}
 
       {pdfUrl && (
@@ -155,10 +224,27 @@ export function EditorialViewerPage() {
               target="_blank"
             >
               {t('editorial.download')}
-            </a>
+            </a>{' '}
+            <Link className="action-link action-link--secondary" to={detailRoute}>
+              {t('editorial.backToDetail')}
+            </Link>
           </p>
         </object>
       )}
+
+      <details className="source-metadata">
+        <summary>{t('editorial.sourceMetadata')}</summary>
+        <dl className="source-metadata__list">
+          <div className="source-metadata__row">
+            <dt>{t('editorial.path')}</dt>
+            <dd>{editorial.path}</dd>
+          </div>
+          <div className="source-metadata__row">
+            <dt>{t('editorial.filename')}</dt>
+            <dd>{editorial.filename}</dd>
+          </div>
+        </dl>
+      </details>
     </article>
   )
 }

--- a/src/pages/EditorialViewerPage.tsx
+++ b/src/pages/EditorialViewerPage.tsx
@@ -1,23 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useParams } from 'react-router-dom'
+import { buildCategoryRoute, getDirectorySegments } from '../shared/api/categoryRoutes'
 import { buildEditorialLinks } from '../shared/api/editorialLinks'
 import { useEditorialIndex } from '../shared/hooks/useEditorialIndex'
 import { usePageMetadata } from '../shared/hooks/usePageMetadata'
 import { getLocalizedText } from '../shared/i18n/getLocalizedText'
-
-function getDirectorySegments(path: string): string[] {
-  const segments = path
-    .split('/')
-    .map((segment) => segment.trim())
-    .filter((segment) => segment.length > 0)
-
-  return segments.slice(0, -1)
-}
-
-function buildCategoryRoute(segments: string[]): string {
-  return `/categories/${segments.map(encodeURIComponent).join('/')}`
-}
 
 export function EditorialViewerPage() {
   const { t, i18n } = useTranslation()

--- a/src/shared/api/categoryRoutes.ts
+++ b/src/shared/api/categoryRoutes.ts
@@ -1,0 +1,14 @@
+/** Returns the folder hierarchy for an editorial path without the final file segment. */
+export function getDirectorySegments(path: string): string[] {
+  const segments = path
+    .split('/')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0)
+
+  return segments.slice(0, -1)
+}
+
+/** Builds the category route for a hierarchy of already-decoded path segments. */
+export function buildCategoryRoute(segments: string[]): string {
+  return `/categories/${segments.map(encodeURIComponent).join('/')}`
+}

--- a/src/shared/i18n/resources.ts
+++ b/src/shared/i18n/resources.ts
@@ -149,6 +149,7 @@ export const resources = {
         filename: 'Filename',
         view: 'View',
         download: 'Download',
+        backToDetail: 'Back to editorial',
         browseContest: 'Browse contest',
         categoryNavigation: 'Category navigation',
         sourceMetadata: 'Source metadata',
@@ -161,6 +162,9 @@ export const resources = {
         viewerDescription: 'Preview this editorial PDF directly in your browser.',
         viewerLoading: 'Preparing PDF viewer...',
         viewerLoadFailed: 'Unable to load this PDF in the browser viewer.',
+        viewerFailureDescription:
+          'You can still download the source file or return to the editorial detail page.',
+        viewerFailureActions: 'PDF viewer fallback actions',
         viewerFallback: 'If preview is not available, use:',
       },
       contribute: {
@@ -385,6 +389,7 @@ export const resources = {
         filename: '파일명',
         view: '열기',
         download: '다운로드',
+        backToDetail: '에디토리얼로 돌아가기',
         browseContest: '대회 둘러보기',
         categoryNavigation: '카테고리 탐색',
         sourceMetadata: '원본 메타데이터',
@@ -397,6 +402,9 @@ export const resources = {
         viewerDescription: '브라우저에서 이 에디토리얼 PDF를 바로 볼 수 있습니다.',
         viewerLoading: 'PDF 뷰어를 준비하는 중입니다...',
         viewerLoadFailed: '브라우저 뷰어에서 이 PDF를 불러오지 못했습니다.',
+        viewerFailureDescription:
+          '원본 파일을 다운로드하거나 에디토리얼 상세 페이지로 돌아갈 수 있습니다.',
+        viewerFailureActions: 'PDF 뷰어 대체 동작',
         viewerFallback: '미리보기가 불가능하면 다음을 사용하세요:',
       },
       contribute: {
@@ -618,6 +626,7 @@ export const resources = {
         filename: 'ファイル名',
         view: '表示',
         download: 'ダウンロード',
+        backToDetail: 'エディトリアルに戻る',
         browseContest: '大会を見る',
         categoryNavigation: 'カテゴリナビゲーション',
         sourceMetadata: '元データのメタ情報',
@@ -630,6 +639,9 @@ export const resources = {
         viewerDescription: 'このエディトリアル PDF をブラウザで直接表示します。',
         viewerLoading: 'PDF ビューアーを準備しています...',
         viewerLoadFailed: 'ブラウザビューアーでこの PDF を読み込めませんでした。',
+        viewerFailureDescription:
+          '元ファイルをダウンロードするか、エディトリアル詳細ページに戻ることができます。',
+        viewerFailureActions: 'PDF ビューアーの代替操作',
         viewerFallback: 'プレビューできない場合は次を使用してください:',
       },
       contribute: {


### PR DESCRIPTION
## What

Add stronger navigation and fallback actions to the PDF viewer page. The viewer now links back to the editorial detail page, includes contest/category navigation, keeps download easy to find, and moves the full source path into secondary metadata.

Closes #115.

## Why

PDF preview failures previously left users with too little direction, and the viewer surfaced the full repository path as primary page content. This gives users clearer next actions while keeping attribution/debug metadata available in a less prominent place.

## Checklist

### Required

- [x] `npm run format:check` passes
- [x] `npm run lint` passes
- [x] `npm run analyze` passes
- [x] `npm run build` passes
- [x] I linked the related issue (for example: `Closes #19`)

### Functional Validation

- [ ] Search/filter/navigation behavior was verified for this change (if applicable)
- [x] Editorial index generation impact was verified (run `npm run index:generate` if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`/`ARCHITECTURE.md`, if applicable)
- [x] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Breaking behavior changes are clearly described in this PR
- [x] i18n updates are included for `en`, `ko`, and `ja` where needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category navigation links and statistics display to the editorial viewer
  * Introduced a collapsible source metadata section
  * Enhanced PDF error fallback to offer download and a "back to detail" action
  * Added translations for new UI elements in English, Korean, and Japanese

* **Style**
  * Added viewer fallback CSS to improve layout and spacing of error display
<!-- end of auto-generated comment: release notes by coderabbit.ai -->